### PR TITLE
Better close behavior

### DIFF
--- a/js/.eslintrc.json
+++ b/js/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": [
+        "standard"
+    ],
+    "parserOptions": {
+        "ecmaVersion": 12
+    },
+    "rules": {
+        "no-var": "off",
+        "camelcase": "off",
+        "prefer-const": "off",
+        "indent": ["error", 4],
+        "semi": ["error", "always"],
+        "comma-dangle": ["error", "only-multiline"],
+        "no-multiple-empty-lines": ["error", {"max": 2}]
+    }
+}

--- a/js/lib/widget.js
+++ b/js/lib/widget.js
@@ -2,17 +2,18 @@ var widgets = require('@jupyter-widgets/base');
 var _ = require('lodash');
 
 /*
- * See widget.py for the kernel counterpart to this file.
+ * For the kernel counterpart to this file, see widget.py
+ * For the base class, see https://github.com/jupyter-widgets/ipywidgets/blob/master/packages/base/src/widget.ts
  *
  * The server sends frames to the client, and the client sends back
  * a confirmation when it has processed the frame.
- * 
+ *
  * The client queues the frames it receives and processes them one-by-one
  * at the browser's pace, using requestAnimationFrame. We send back a
  * confirmation when the frame is processed (not when it is technically received).
  * It is the responsibility of the server to not send too many frames beyond the
  * last confirmed one.
- * 
+ *
  * When setting the img.src attribute, the browser still needs to actually render
  * the image. We wait for this before requesting a new animation. If we don't do
  * this on FF, the animation is not smooth because the image "gets stuck".
@@ -22,44 +23,44 @@ var _ = require('lodash');
 var RemoteFrameBufferModel = widgets.DOMWidgetModel.extend({
     defaults: _.extend(widgets.DOMWidgetModel.prototype.defaults(), {
         // Meta info
-        _model_name : 'RemoteFrameBufferModel',
-        _view_name : 'RemoteFrameBufferView',
-        _model_module : 'jupyter_rfb',
-        _view_module : 'jupyter_rfb',
-        _model_module_version : '0.1.0',
-        _view_module_version : '0.1.0',
+        _model_name: 'RemoteFrameBufferModel',
+        _view_name: 'RemoteFrameBufferView',
+        _model_module: 'jupyter_rfb',
+        _view_module: 'jupyter_rfb',
+        _model_module_version: '0.1.0',
+        _view_module_version: '0.1.0',
         // For the frames
-        frame_feedback : {},
+        frame_feedback: {},
         // For the widget
-        css_width : '100%',
-        css_height : '300px',
-        resizable : true
+        css_width: '100%',
+        css_height: '300px',
+        resizable: true
     }),
 
     initialize: function () {
-        RemoteFrameBufferModel.__super__.initialize.apply(this, arguments);        
-        window.rfb_model = this;  // Debug
+        RemoteFrameBufferModel.__super__.initialize.apply(this, arguments);
+        window.rfb_model = this; // Debug
         // Keep a list if img elements, and auto-refresh it.
         this.img_elements = [];
         window.setInterval(this.resolve_img_elements.bind(this), 1000);
-         // Keep a list of frames to render
+        // Keep a list of frames to render
         this.frames = [];
         // We populate the above list from this callback
-        this.on('msg:custom', this.on_msg, this);                
+        this.on('msg:custom', this.on_msg, this);
         // Initialize a stub frame
         this.last_frame = {
-            src: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR42mOor68HAAL+AX6E2KOJAAAAAElFTkSuQmCC",
+            src: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR42mOor68HAAL+AX6E2KOJAAAAAElFTkSuQmCC',
             index: 0,
             timestamp: 0,
-        }
+        };
         // Start the animation loop
         this._img_update_pending = false;
-        this._request_animation_frame();        
+        this._request_animation_frame();
     },
 
-    resolve_img_elements: async function() {
+    resolve_img_elements: async function () {
         // Here we collect img elements corresponding to the current views.
-        // We also set their onload methods which we use to schedule new draws.        
+        // We also set their onload methods which we use to schedule new draws.
         // Reset
         for (let img of this.img_elements) {
             img.onload = null;
@@ -75,16 +76,16 @@ var RemoteFrameBufferModel = widgets.DOMWidgetModel.extend({
         this._request_animation_frame();
     },
 
-    on_msg: function(msg, buffers) {
-        if (msg.type == "framebufferdata") {
+    on_msg: function (msg, buffers) {
+        if (msg.type === 'framebufferdata') {
             this.frames.push(msg);
-        }        
+        }
     },
 
-    _send_response: function() {
+    _send_response: function () {
         // Let Python know what we have at the model. This prop is a dict, making it "atomic".
         let frame = this.last_frame;
-        let frame_feedback = {index: frame.index, timestamp: frame.timestamp, localtime: Date.now() / 1000};
+        let frame_feedback = { index: frame.index, timestamp: frame.timestamp, localtime: Date.now() / 1000 };
         this.set('frame_feedback', frame_feedback);
         this.save_changes();
     },
@@ -99,7 +100,7 @@ var RemoteFrameBufferModel = widgets.DOMWidgetModel.extend({
         }
     },
 
-    _animate: function() {
+    _animate: function () {
         this._img_update_pending = false;
         if (!this.frames.length) {
             this._request_animation_frame();
@@ -115,31 +116,37 @@ var RemoteFrameBufferModel = widgets.DOMWidgetModel.extend({
         this.last_frame = frame;
         this._send_response();
         // Request a new frame. If we have images, a frame is requested *after* they load.
-        if (this.img_elements.length == 0) {
+        if (this.img_elements.length === 0) {
             this._request_animation_frame();
         }
+    },
+
+    close: function () {
+        // This gets called when model is closed and the comm is removed. Notify Py just in time!
+        this.send({ event_type: 'close' }); // does nothing if this.comm is already gone
+        RemoteFrameBufferModel.__super__.close.apply(this, arguments);
     },
 });
 
 
 var RemoteFrameBufferView = widgets.DOMWidgetView.extend({
     // Defines how the widget gets rendered into the DOM
-    render: function() {
+    render: function () {
         var that = this;
 
         // Create image element
         this.img = new Image();
-        // Tweak loading behavior. These should be the defaults, but we set them just in case. 
-        this.img.decoding = "sync";
-        this.img.loading = "eager";
+        // Tweak loading behavior. These should be the defaults, but we set them just in case.
+        this.img.decoding = 'sync';
+        this.img.loading = 'eager';
         // Tweak mouse/touch/pointer/key behavior
-        this.img.style.touchAction = "none";  // prevent default pan/zoom behavior
-        this.img.ondragstart = () => false;  // prevent browser's built-in image drag
+        this.img.style.touchAction = 'none'; // prevent default pan/zoom behavior
+        this.img.ondragstart = () => false; // prevent browser's built-in image drag
         this.img.tabIndex = -1;
         // Prevent context menu on RMB. Firefox still shows it when shift is pressed. It seems
         // impossible to override this (tips welcome!), so let's make this the actual behavior.
-        this.img.oncontextmenu = function(e) { if (!e.shiftKey) { e.preventDefault(); e.stopPropagation(); return false; }};
-        
+        this.img.oncontextmenu = function (e) { if (!e.shiftKey) { e.preventDefault(); e.stopPropagation(); return false; } };
+
         // Initialize the image
         this.img.src = this.model.last_frame.src;
         this.el.appendChild(this.img);
@@ -149,8 +156,8 @@ var RemoteFrameBufferView = widgets.DOMWidgetView.extend({
         this._throttlers = {};
 
         // Initialize sizing. Setting the this.el's size right now has no effect for some reason, so we use a timer.
-        this.img.style.width = "100%";
-        this.img.style.height = "100%";
+        this.img.style.width = '100%';
+        this.img.style.height = '100%';
         this.el.style.resize = this.model.get('resizable') ? 'both' : 'none';
         window.setTimeout(() => { this.el.style.width = this.model.get('css_width'); }, 1);
         window.setTimeout(() => { this.el.style.height = this.model.get('css_height'); }, 1);
@@ -159,29 +166,29 @@ var RemoteFrameBufferView = widgets.DOMWidgetView.extend({
         this.model.on('change:css_width', function () { this.el.style.width = this.model.get('css_width'); }, this);
         this.model.on('change:css_height', function () { this.el.style.height = this.model.get('css_height'); }, this);
         this.model.on('change:resizable', function () { this.el.style.resize = this.model.get('resizable') ? 'both' : 'none'; }, this);
-        
+
         // Keep track of size changes in JS, so we can notify the server
         this._current_size = [0, 0, 1];
         this._resizeObserver = new ResizeObserver(this._check_resize.bind(that));
         this._resizeObserver.observe(this.img);
-        window.addEventListener("resize", this._check_resize.bind(this));       
-        
+        window.addEventListener('resize', this._check_resize.bind(this));
+
         // Pointer events
         this._pointers = {};
         this.img.addEventListener('pointerdown', function (e) {
             // This is what makes the JS PointerEvent so great. We can enable mouse capturing
             // and we will receive mouse-move and mouse-up even when the pointer moves outside
-            // the element. Best of all, the capturing is disabled automatically! 
+            // the element. Best of all, the capturing is disabled automatically!
             that.img.setPointerCapture(e.pointerId);
             that._pointers[e.pointerId] = e;
-            let event = create_pointer_event(that.img, e, that._pointers, "pointer_down");
+            let event = create_pointer_event(that.img, e, that._pointers, 'pointer_down');
             that.send(event);
             if (!e.altKey) { e.preventDefault(); }
         });
         this.img.addEventListener('lostpointercapture', function (e) {
             // This happens on pointer-up or pointer-cancel. We threat them the same.
             // The event we emit will still include the touch hat goes up.
-            let event = create_pointer_event(that.img, e, that._pointers, "pointer_up");
+            let event = create_pointer_event(that.img, e, that._pointers, 'pointer_up');
             delete that._pointers[e.pointerId];
             that.send(event);
         });
@@ -190,27 +197,27 @@ var RemoteFrameBufferView = widgets.DOMWidgetView.extend({
             if (that._pointers[e.pointerId] === undefined) {
                 if (Object.keys(that._pointers).length > 0) { return; }
             }
-            let event = create_pointer_event(that.img, e, that._pointers, "pointer_move");
+            let event = create_pointer_event(that.img, e, that._pointers, 'pointer_move');
             that.send_throttled(event, 50);
         });
 
         // Click events are not pointer events. Not sure if we need click events. It seems to make
         // less sense, because the img is just a single element. Only double-click for now.
-        this.img.addEventListener('dblclick', function (e) {            
-            let event = create_pointer_event(that.img, e, {}, "double_click");
-            delete event["touches"];
-            delete event["ntouches"];
+        this.img.addEventListener('dblclick', function (e) {
+            let event = create_pointer_event(that.img, e, {}, 'double_click');
+            delete event.touches;
+            delete event.ntouches;
             that.send(event);
             if (!e.altKey) { e.preventDefault(); }
         });
 
         // Scrolling. Need a special throttling that accumulates the deltas.
-        this._wheel_state = {dx: 0, dy: 0, e: null, pending: false};
-        function send_wheel_event() {
-            let e = that._wheel_state.e;            
-            let rect = that.img.getBoundingClientRect();            
+        this._wheel_state = { dx: 0, dy: 0, e: null, pending: false };
+        function send_wheel_event () {
+            let e = that._wheel_state.e;
+            let rect = that.img.getBoundingClientRect();
             let event = {
-                event_type: "wheel",
+                event_type: 'wheel',
                 x: Number(e.clientX - rect.left),
                 y: Number(e.clientY - rect.top),
                 dx: that._wheel_state.dx,
@@ -234,23 +241,23 @@ var RemoteFrameBufferView = widgets.DOMWidgetView.extend({
         });
 
         // Key events - approach inspired from ipyevents
-        function key_event_handler(e) {
-            // Failsafe in case the element is deleted
+        function key_event_handler (e) {
+            // Failsafe in case the element is deleted or detached.
             if (that.el.offsetParent === null) { return disable_key_event(); }
             let event = {
-                event_type: "key_" + e.type.slice(3),
+                event_type: 'key_' + e.type.slice(3),
                 key: KEYMAP[e.key] || e.key,
                 modifiers: get_modifiers(e),
             };
-            if (!e.repeat) { that.send(event); }  // dont do the sticky key thing
+            if (!e.repeat) { that.send(event); } // dont do the sticky key thing
             e.stopPropagation();
             e.preventDefault();
         }
-        function enable_key_event() {
-                document.addEventListener('keydown', key_event_handler, true);
-                document.addEventListener('keyup', key_event_handler, true);
+        function enable_key_event () {
+            document.addEventListener('keydown', key_event_handler, true);
+            document.addEventListener('keyup', key_event_handler, true);
         }
-        function disable_key_event() {
+        function disable_key_event () {
             document.removeEventListener('keydown', key_event_handler, true);
             document.removeEventListener('keyup', key_event_handler, true);
         }
@@ -258,21 +265,26 @@ var RemoteFrameBufferView = widgets.DOMWidgetView.extend({
         this.el.addEventListener('pointerout', disable_key_event, true);
     },
 
-    _check_resize: function() {
+    remove: function () {
+        // This gets called when the view is removed from the DOM. There can still be other views though!
+        RemoteFrameBufferView.__super__.remove.apply(this, arguments);
+    },
+
+    _check_resize: function () {
         // Called when the widget resizes. Width and height are in logical pixels.
         let w = this.img.clientWidth;
         let h = this.img.clientHeight;
         let r = window.devicePixelRatio;
-        if (w == 0 && h == 0) { return; }
-        if (this._current_size[0] != w || this._current_size[1] != h || this._current_size[2] != r) {
+        if (w === 0 && h === 0) { return; }
+        if (this._current_size[0] !== w || this._current_size[1] !== h || this._current_size[2] !== r) {
             this._current_size = [w, h, r];
-            this.send_throttled({event_type: 'resize', width: w, height: h, pixel_ratio: r}, 200);
+            this.send_throttled({ event_type: 'resize', width: w, height: h, pixel_ratio: r }, 200);
         }
     },
-        
-    send_throttled: function(msg, wait) {
+
+    send_throttled: function (msg, wait) {
         // Like .send(), but throttled
-        let event_type = msg.event_type || "";        
+        let event_type = msg.event_type || '';
         let func = this._throttlers[event_type];
         if (func === undefined) {
             func = throttled(this.send, wait || 100);
@@ -285,47 +297,47 @@ var RemoteFrameBufferView = widgets.DOMWidgetView.extend({
 
 
 var KEYMAP = {
-    "Ctrl": "Control",
-    "Del": "Delete",
-    "Esc": "Escape",
+    Ctrl: 'Control',
+    Del: 'Delete',
+    Esc: 'Escape',
 };
 
 
-function get_modifiers(e) {    
-    let modifiers = ["Alt", "Shift", "Ctrl", "Meta"].filter((n) => e[n.toLowerCase() + 'Key']);
+function get_modifiers (e) {
+    let modifiers = ['Alt', 'Shift', 'Ctrl', 'Meta'].filter((n) => e[n.toLowerCase() + 'Key']);
     return modifiers.map((m) => KEYMAP[m] || m);
 }
 
 
-function throttled(func, wait) {
+function throttled (func, wait) {
     var context, args, result;
     var timeout = null;
     var previous = 0;
-    var later = function() {
+    var later = function () {
         previous = Date.now();
         timeout = null;
         result = func.apply(context, args);
         if (!timeout) context = args = null;
-    };    
-    return function() {
-      var now = Date.now();
-      var remaining = wait - (now - previous);
-      context = this;
-      args = arguments;
-      if (remaining <= 0 || remaining > wait) {
+    };
+    return function () {
+        var now = Date.now();
+        var remaining = wait - (now - previous);
+        context = this;
+        args = arguments;
+        if (remaining <= 0 || remaining > wait) {
             if (timeout) { clearTimeout(timeout); timeout = null; }
             previous = now;
             result = func.apply(context, args);
             if (!timeout) context = args = null;
-      } else if (!timeout) {
-          timeout = setTimeout(later, remaining);
-      }
-      return result;
+        } else if (!timeout) {
+            timeout = setTimeout(later, remaining);
+        }
+        return result;
     };
 }
 
 
-function create_pointer_event(el, e, pointers, event_type) {
+function create_pointer_event (el, e, pointers, event_type) {
     let rect = el.getBoundingClientRect();
     let offset = [rect.left, rect.top];
     let main_x = Number(e.clientX - offset[0]);
@@ -335,19 +347,19 @@ function create_pointer_event(el, e, pointers, event_type) {
     let touches = {};
     let ntouches = 0;
     for (let pointer_id in pointers) {
-        let pe = pointers[pointer_id];   // pointer event
+        let pe = pointers[pointer_id]; // pointer event
         let x = Number(pe.clientX - offset[0]);
         let y = Number(pe.clientY - offset[1]);
-        let touch = {x: x, y: y, pressure: pe.pressure};
+        let touch = { x: x, y: y, pressure: pe.pressure };
         touches[pe.pointerId] = touch;
         ntouches += 1;
     }
 
     // Get button that changed, and the button state
-    var button = {0: 1, 1: 3, 2: 2, 3: 4, 4: 5, 5: 6}[e.button] || 0;
+    var button = { 0: 1, 1: 3, 2: 2, 3: 4, 4: 5, 5: 6 }[e.button] || 0;
     var buttons = [];
     for (let b of [0, 1, 2, 3, 4, 5]) { if ((1 << b) & e.buttons) { buttons.push(b + 1); } }
-    
+
     return {
         event_type: event_type,
         x: main_x,
@@ -357,7 +369,7 @@ function create_pointer_event(el, e, pointers, event_type) {
         modifiers: get_modifiers(e),
         ntouches: ntouches,
         touches: touches,
-    }
+    };
 }
 
 

--- a/js/package.json
+++ b/js/package.json
@@ -31,8 +31,9 @@
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.0.0",
+    "rimraf": "^2.6.1",
     "webpack": "^5",
-    "rimraf": "^2.6.1"
+    "webpack-cli": "^4.7.2"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.1 || ^2 || ^3 || ^4",


### PR DESCRIPTION
* The client sends a `close` event when the widget is closed from JS.
* The server mimics a `close` event when the widget is closed from Py.
* Also applied linting+formatting (via eslint) of the JS code to detect possible bugs. Sorry, this messes up the pr a bit.