### PR TITLE
Refactor so frames are auto-requested instead of pushed

### DIFF
--- a/examples/drawing1.ipynb
+++ b/examples/drawing1.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "28b38e38",
+   "metadata": {},
+   "source": [
+    "# Drawing example 1\n",
+    "A simple drawing app:\n",
+    "* Draw dots by clicking with LMB.\n",
+    "* Toggle color by clicking RMB."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "fb037e0b",
@@ -21,7 +32,7 @@
     "        self.pen_colors = [(1, 0.2, 0, 1), (0, 1, 0.2, 1), (0.2, 0, 1, 1)]\n",
     "        self.pen_index = 0        \n",
     "    \n",
-    "    def receive_event(self, event):\n",
+    "    def handle_event(self, event):\n",
     "        event_type = event.get(\"event_type\", None)\n",
     "        if event_type == \"resize\":\n",
     "            # Take pixel ratio into account, use 8x less pixels (in each dim)\n",
@@ -29,22 +40,33 @@
     "            w = int(event[\"width\"] * self.pixel_ratio)\n",
     "            h = int(event[\"height\"] * self.pixel_ratio)\n",
     "            self.array = np.zeros((h, w, 4), np.uint8)\n",
-    "            self.send_frame(self.array)\n",
+    "            #self.send_frame(self.array)\n",
     "        if event_type == \"pointer_down\":\n",
     "            if event[\"button\"] == 1:\n",
     "                # Draw\n",
     "                x = int(event[\"x\"] * self.pixel_ratio)\n",
     "                y = int(event[\"y\"] * self.pixel_ratio)\n",
     "                self.array[y, x] = 255 * np.array(self.pen_colors[self.pen_index])\n",
-    "                self.send_frame(self.array)\n",
+    "                self.request_draw()\n",
     "            elif event[\"button\"] == 2:\n",
     "                # Toggle color\n",
     "                self.pen_index = (self.pen_index + 1) % len(self.pen_colors)\n",
-    "\n",
+    "    \n",
+    "    def get_frame(self):\n",
+    "        return self.array\n",
+    "        \n",
     "\n",
     "app = Drawingapp()\n",
     "app"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffaab5a0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/hello_world.ipynb
+++ b/examples/hello_world.ipynb
@@ -12,27 +12,57 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7691480a",
+   "id": "eb328d8f",
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import jupyter_rfb\n",
+    "import jupyter_rfb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7691480a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class HelloWorld1(jupyter_rfb.RemoteFrameBuffer):\n",
+    "    \"\"\" A simple example drawing a 100x100 image depicting a green rectangle with a black edge. \"\"\"\n",
     "\n",
-    "w = jupyter_rfb.RemoteFrameBuffer()\n",
+    "    def get_frame(self):\n",
+    "        a = np.zeros((100, 100, 3), np.uint8)\n",
+    "        a[20:-20,20:-20,1] = 255\n",
+    "        return a\n",
+    "\n",
+    "w = HelloWorld1()\n",
     "w"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5192779f",
+   "id": "45578bd6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "a = np.zeros((100, 100, 3), np.uint8)\n",
-    "a[20:-20,20:-20,1] = 255\n",
-    "w.send_frame(a)"
+    "class HelloWorld2(jupyter_rfb.RemoteFrameBuffer):\n",
+    "    \"\"\" An example that takes the size of the widget (including zoom/high-res) into account. \"\"\"\n",
+    "    \n",
+    "    def handle_event(self, event):\n",
+    "        if event[\"event_type\"] == \"resize\":\n",
+    "            self._size = event\n",
+    "        \n",
+    "    def get_frame(self):\n",
+    "        w, h, r = self._size[\"width\"], self._size[\"height\"], self._size[\"pixel_ratio\"]\n",
+    "        physical_size = int(h*r), int(w*r)\n",
+    "        a = np.zeros((physical_size[0], physical_size[1], 3), np.uint8)\n",
+    "        margin = int(20 * r)\n",
+    "        a[margin:-margin,margin:-margin,1] = 255\n",
+    "        return a\n",
+    "\n",
+    "w = HelloWorld2()\n",
+    "w"
    ]
   }
  ],

--- a/examples/performance.ipynb
+++ b/examples/performance.ipynb
@@ -20,14 +20,24 @@
     "import numpy as np\n",
     "from jupyter_rfb import RemoteFrameBuffer\n",
     "\n",
-    "class FramePusher(RemoteFrameBuffer):        \n",
-    "    def run(self, n=100):\n",
+    "class FramePusher(RemoteFrameBuffer):\n",
+    "    i = 0\n",
+    "    n = 0\n",
+    "    \n",
+    "    def get_frame(self):\n",
+    "        if self.i >= self.n:\n",
+    "            return None\n",
     "        array = np.zeros((640, 480), np.uint8)\n",
-    "        self._timer = time.perf_counter(), n\n",
-    "        for i in range(n):\n",
-    "            # array = np.random.uniform(0, 255, (640, 480)).astype(np.uint8)\n",
-    "            array[:20,: int(array.shape[1] * (i + 1) / n)] = 255\n",
-    "            self.send_frame(array.copy())        \n",
+    "        # array = np.random.uniform(0, 255, (640, 480)).astype(np.uint8)\n",
+    "        array[:20,: int(array.shape[1] * (self.i + 1) / self.n)] = 255\n",
+    "        self.i += 1\n",
+    "        self.request_draw()  # keep going\n",
+    "        return array\n",
+    "\n",
+    "    def run(self, n=100):\n",
+    "        self.i = 0\n",
+    "        self.n = n\n",
+    "        self.request_draw()\n",
     "        \n",
     "w = FramePusher(css_height='100px')"
    ]
@@ -50,7 +60,6 @@
    "outputs": [],
    "source": [
     "n = 50\n",
-    "w.max_queued_frames = 999\n",
     "w.max_buffered_frames = 2\n",
     "w.reset_stats()\n",
     "w.run(n)"
@@ -64,8 +73,16 @@
    "outputs": [],
    "source": [
     "# Call this when it's done\n",
-    "w.stats\n"
+    "w.stats"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c77e31a0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/performance.ipynb
+++ b/examples/performance.ipynb
@@ -20,7 +20,7 @@
     "import numpy as np\n",
     "from jupyter_rfb import RemoteFrameBuffer\n",
     "\n",
-    "class FramePusher(RemoteFrameBuffer):\n",
+    "class PerformanceTester(RemoteFrameBuffer):\n",
     "    i = 0\n",
     "    n = 0\n",
     "    \n",
@@ -39,7 +39,7 @@
     "        self.n = n\n",
     "        self.request_draw()\n",
     "        \n",
-    "w = FramePusher(css_height='100px')"
+    "w = PerformanceTester(css_height='100px')"
    ]
   },
   {

--- a/examples/push.ipynb
+++ b/examples/push.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f011941f",
+   "metadata": {},
+   "source": [
+    "# Push example\n",
+    "The default behavior of `jupyter_rfb` is to automatically call `get_frame()` when a new draw is requested and when the widget is ready for it. In use-cases where you want to push frames to the widget, you may prefer a different approach. Here is an example solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c278a5e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from jupyter_rfb import RemoteFrameBuffer\n",
+    "\n",
+    "class FramePusher(RemoteFrameBuffer):\n",
+    "    def __init__(self, **kwargs):\n",
+    "        super().__init__(**kwargs)\n",
+    "        self._queue = []\n",
+    "    \n",
+    "    def push_frame(self, frame):\n",
+    "        self._queue.append(frame)\n",
+    "        self._queue[:-10] = [] # drop older frames if len > 10   \n",
+    "        self.request_draw()\n",
+    "    \n",
+    "    def get_frame(self):\n",
+    "        if not self._queue:\n",
+    "            return\n",
+    "        self.request_draw()\n",
+    "        return self._queue.pop(0)\n",
+    "        \n",
+    "w = FramePusher(css_width='100px', css_height='100px')\n",
+    "w"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bade53a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w.push_frame(np.random.uniform(0, 255, (100, 100)).astype(np.uint8))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2156c042",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Push 20 frames. Note that only the latest 10 will be shown\n",
+    "for i in range(20):\n",
+    "    w.push_frame(np.random.uniform(0, 255, (100, 100)).astype(np.uint8))\n",
+    "len(w._queue)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ed1d6a9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/video.ipynb
+++ b/examples/video.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9416c1c1",
+   "metadata": {},
+   "source": [
+    "# Video example\n",
+    "Plays a video as fast as it can"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19dd4c54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import imageio\n",
+    "import numpy as np\n",
+    "from jupyter_rfb import RemoteFrameBuffer\n",
+    "\n",
+    "r = imageio.get_reader(\"imageio:cockatoo.mp4\", \"ffmpeg\")\n",
+    "\n",
+    "class VideoPlayer(RemoteFrameBuffer):\n",
+    "    \n",
+    "    def get_frame(self):\n",
+    "        v.request_draw()\n",
+    "        return r.get_next_data()\n",
+    "\n",
+    "\n",
+    "v = VideoPlayer(max_buffered_frames=3)\n",
+    "v"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b603178b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/vispy.ipynb
+++ b/examples/vispy.ipynb
@@ -43,6 +43,14 @@
     "view.camera.set_range(x=[-3, 3])\n",
     "canvas"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc90dfc5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/wgpu.ipynb
+++ b/examples/wgpu.ipynb
@@ -186,14 +186,13 @@
     "        super().__init__()\n",
     "        self._pixel_ratio = 1\n",
     "        self._logical_size = 0, 0\n",
+    "        self._arr = None\n",
     "   \n",
-    "    def receive_event(self, event):\n",
+    "    def handle_event(self, event):\n",
     "        event_type = event.get(\"event_type\", \"\")\n",
     "        if event_type == \"resize\":\n",
     "            self._pixel_ratio = event[\"pixel_ratio\"]\n",
     "            self._logical_size = event[\"width\"], event[\"height\"]\n",
-    "            # todo: request draw?\n",
-    "            self._request_draw()\n",
     "    \n",
     "    def get_pixel_ratio(self):\n",
     "        return self._pixel_ratio\n",
@@ -209,12 +208,17 @@
     "        self.css_height = f\"{height}px\"\n",
     "    \n",
     "    def _request_draw(self):\n",
+    "        RemoteFrameBuffer.request_draw(self)\n",
     "        # todo: de-dupe\n",
-    "        ioloop = tornado.ioloop.IOLoop.current()\n",
-    "        ioloop.add_callback(self._draw_frame_and_present)\n",
-    "        \n",
+    "        #ioloop = tornado.ioloop.IOLoop.current()\n",
+    "        #ioloop.add_callback(self._draw_frame_and_present)\n",
+    "    \n",
+    "    def get_frame(self):\n",
+    "        self._arr2 = self._draw_frame_and_present()\n",
+    "        return self._arr\n",
+    "    \n",
     "    def close(self):\n",
-    "        pass # todo: close\n",
+    "        RemoteFrameBuffer.close(self)\n",
     "    \n",
     "    def is_closed(self):\n",
     "        pass # todo: is_closed\n",
@@ -237,8 +241,10 @@
     "            size,\n",
     "        )\n",
     "        arr = np.frombuffer(data, np.uint8).reshape(size[1], size[0], 4)\n",
+    "        self._arr = arr\n",
+    "        return arr\n",
     "        #print(arr.shape)\n",
-    "        self.send_frame(arr[:,:,:3])#.copy())\n",
+    "        #self.send_frame(arr[:,:,:3])#.copy())\n",
     "    "
    ]
   },
@@ -262,6 +268,14 @@
    "source": [
     "main(canvas)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da65404b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/jupyter_rfb/widget.py
+++ b/jupyter_rfb/widget.py
@@ -163,7 +163,7 @@ class RemoteFrameBuffer(FrameSenderMixin, widgets.DOMWidget):
 
     # Widget specific properties
     frame_feedback = Dict({}).tag(sync=True)
-    max_buffered_frames = Int(1, min=1)
+    max_buffered_frames = Int(2, min=1)
 
     css_width = Unicode("100%").tag(sync=True)
     css_height = Unicode("300px").tag(sync=True)

--- a/tests/test_framesender.py
+++ b/tests/test_framesender.py
@@ -8,7 +8,8 @@ from jupyter_rfb.widget import FrameSenderMixin
 class MyFrameSender(FrameSenderMixin):
 
     max_buffered_frames = 1
-    max_queued_frames = 1
+
+    _rfb_draw_requested = False
 
     def __init__(self):
         super().__init__()
@@ -18,122 +19,148 @@ class MyFrameSender(FrameSenderMixin):
     def send(self, msg):
         self.msgs.append(msg)
 
+    def get_frame(self):
+        return np.array([[1, 2], [3, 4]], np.uint8)
 
-def test_framesender_1_1():
+    def trigger(self, request):
+        if request:
+            self._rfb_draw_requested = True
+        self._rfb_maybe_draw()
+
+
+def test_framesender_1():
 
     fs = MyFrameSender()
     fs.max_buffered_frames = 1
-    fs.max_queued_frames = 1
-
-    im = np.array([[1, 2], [3, 4]], np.uint8)
 
     assert len(fs.msgs) == 0
 
-    # Send a frame
-    fs.send_frame(im)
+    # Request a draw
+    fs.trigger(True)
     assert len(fs.msgs) == 1
-    assert len(fs._pending_frames) == 0
 
-    # Send another, this one is queued
-    fs.send_frame(im)
+    # Request another, no draw yet, because previous one is not yet confirmed
+    fs.trigger(True)
+    fs.trigger(True)
+    fs.trigger(True)
     assert len(fs.msgs) == 1
-    assert len(fs._pending_frames) == 1
 
-    # Queue is full, so this one is dropped
-    fs.send_frame(im)
-    assert len(fs.msgs) == 1
-    assert len(fs._pending_frames) == 1
-
-    assert fs.stats["received_frames"] == 3
     assert fs.stats["sent_frames"] == 1
-    assert fs.stats["dropped_frames"] == 1
     assert fs.stats["confirmed_frames"] == 0
 
     # Flush
     fs.frame_feedback["index"] = 1
     fs.frame_feedback["timestamp"] = fs.msgs[-1]["timestamp"]
     fs.frame_feedback["localtime"] = time.time()
-    fs._iter()
 
+    # Trigger, the previous request is still open
+    fs.trigger(False)
     assert len(fs.msgs) == 2
-    assert len(fs._pending_frames) == 0
 
-    # Now we can send another
-    fs.send_frame(im)
-    assert len(fs.msgs) == 2
-    assert len(fs._pending_frames) == 1
-
-    assert fs.stats["received_frames"] == 4
     assert fs.stats["sent_frames"] == 2
-    assert fs.stats["dropped_frames"] == 1
     assert fs.stats["confirmed_frames"] == 1
-
-
-def test_framesender_2_3():
-
-    fs = MyFrameSender()
-    fs.max_buffered_frames = 2
-    fs.max_queued_frames = 3
-
-    im = np.array([[1, 2], [3, 4]], np.uint8)
-
-    assert len(fs.msgs) == 0
-
-    # 1 Send a frame
-    fs.send_frame(im)
-    assert len(fs.msgs) == 1
-    assert len(fs._pending_frames) == 0
-
-    # 2 Send a frame
-    fs.send_frame(im)
-    assert len(fs.msgs) == 2
-    assert len(fs._pending_frames) == 0
-
-    # 1 Send another, this one is queued
-    fs.send_frame(im)
-    assert len(fs.msgs) == 2
-    assert len(fs._pending_frames) == 1
-
-    # 2 Send another, this one is queued
-    fs.send_frame(im)
-    assert len(fs.msgs) == 2
-    assert len(fs._pending_frames) == 2
-
-    # 3 Send another, this one is queued
-    fs.send_frame(im)
-    assert len(fs.msgs) == 2
-    assert len(fs._pending_frames) == 3
-
-    # Queue is full, so this one is dropped
-    fs.send_frame(im)
-    assert len(fs.msgs) == 2
-    assert len(fs._pending_frames) == 3
-
-    assert fs.stats["received_frames"] == 6
-    assert fs.stats["sent_frames"] == 2
-    assert fs.stats["dropped_frames"] == 1
-    assert fs.stats["confirmed_frames"] == 0
 
     # Flush
     fs.frame_feedback["index"] = 2
     fs.frame_feedback["timestamp"] = fs.msgs[-1]["timestamp"]
     fs.frame_feedback["localtime"] = time.time()
-    fs._iter()
 
-    assert len(fs.msgs) == 4
-    assert len(fs._pending_frames) == 1
+    fs.trigger(False)
+    assert len(fs.msgs) == 2
 
-    # Now we can send another
-    fs.send_frame(im)
-    assert len(fs.msgs) == 4
-    assert len(fs._pending_frames) == 2
+    assert fs.stats["sent_frames"] == 2
+    assert fs.stats["confirmed_frames"] == 2
 
-    assert fs.stats["received_frames"] == 7
-    assert fs.stats["sent_frames"] == 4
-    assert fs.stats["dropped_frames"] == 1
+    # Trigger with no request do not trigger a draw
+    # We *can* draw but *should* not.
+    fs.trigger(False)
+    assert len(fs.msgs) == 2
+
+    assert fs.stats["sent_frames"] == 2
+    assert fs.stats["confirmed_frames"] == 2
+
+    # One more draw
+    fs.trigger(True)
+    assert len(fs.msgs) == 3
+
+    assert fs.stats["sent_frames"] == 3
     assert fs.stats["confirmed_frames"] == 2
 
 
+def test_framesender_3():
+
+    fs = MyFrameSender()
+    fs.max_buffered_frames = 3
+
+    assert len(fs.msgs) == 0
+
+    # 1 Send a frame
+    fs.trigger(True)
+    assert len(fs.msgs) == 1
+
+    # 2 Send a frame
+    fs.trigger(True)
+    assert len(fs.msgs) == 2
+
+    # 3 Send a frame
+    fs.trigger(True)
+    assert len(fs.msgs) == 3
+
+    # 4 Send a frame - no draw, because first (3 frames ago) is no confirmed
+    fs.trigger(True)
+    assert len(fs.msgs) == 3
+
+    assert fs.stats["sent_frames"] == 3
+    assert fs.stats["confirmed_frames"] == 0
+
+    # Flush
+    fs.frame_feedback["index"] = 3
+    fs.frame_feedback["timestamp"] = fs.msgs[-1]["timestamp"]
+    fs.frame_feedback["localtime"] = time.time()
+
+    # Trigger with True. We request a new frame, but there was a request open
+    fs.trigger(True)
+    assert len(fs.msgs) == 4
+
+    assert fs.stats["sent_frames"] == 4
+    assert fs.stats["confirmed_frames"] == 3
+
+    # Flush
+    fs.frame_feedback["index"] = 4
+    fs.frame_feedback["timestamp"] = fs.msgs[-1]["timestamp"]
+    fs.frame_feedback["localtime"] = time.time()
+
+    # Trigger, but nothing to send (no frame pending)
+    fs.trigger(False)
+    assert len(fs.msgs) == 4
+
+    assert fs.stats["sent_frames"] == 4
+    assert fs.stats["confirmed_frames"] == 4
+
+    # We can but should not do a draw
+    fs.trigger(False)
+    assert len(fs.msgs) == 4
+
+    # Do three more draws
+    fs.trigger(True)
+    fs.trigger(True)
+    fs.trigger(True)
+    assert len(fs.msgs) == 7
+
+    # And request another (but this one will have to wait)
+    fs.trigger(True)
+    assert len(fs.msgs) == 7
+
+    # Flush
+    fs.frame_feedback["index"] = 7
+    fs.frame_feedback["timestamp"] = fs.msgs[-1]["timestamp"]
+    fs.frame_feedback["localtime"] = time.time()
+
+    # Trigger with False. no new request, but there was a request open
+    fs.trigger(False)
+    assert len(fs.msgs) == 8
+
+
 if __name__ == "__main__":
-    test_framesender_1_1()
-    test_framesender_2_3()
+    test_framesender_1()
+    test_framesender_3()


### PR DESCRIPTION
closes #18, see that issue for the motivation

I initially planned to add methods `on_draw()` and `on_event()`, but in ipywidgets, `on_xx` is a pattern used to register callbacks, so that would be confusing. 

* [x] Remove `send_frame()` in favor of `get_frame()` that gets automatically called.
* [x] Adds `request_draw()` to request a new draw.
* [x] Rename `receive_event()` to `handle_event()`.
* [x] Added an `_rfb_` prefix to all `_privates` to avoid name clashes. 