### PR TITLE
Update binder env to install jupyter_rfb from pip

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,13 +2,8 @@ name: jupyter_rfb
 channels:
  - conda-forge
 dependencies:
- - nodejs
- - yarn
  - pip:
-   - traittypes
-   - traitlets
-   - ipywidgets>=7.4
-   - notebook>=5.3
+   - jupyter_rfb
    - numpy
    - Pillow
    - imageio

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,1 @@
 #!/bin/bash
-
-set -ex
-
-pip install .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ nbsphinx_prolog = """
         </a>
 
         <a class=''
-            href='https://mybinder.org/v2/gh/vispy/jupyter_rfb/main?filepath={{ env.docname }}.ipynb'
+            href='https://mybinder.org/v2/gh/vispy/jupyter_rfb/main?urlpath=tree/{{ env.docname }}.ipynb'
             >
         <img src='https://mybinder.org/badge_logo.svg' />
         </a>


### PR DESCRIPTION
This:
* Makes that we can use mybinder to test the wheel on Pypi :)
* Should reduce the time it takes to create a fresh mybinder Docker image.