### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/release.py
+++ b/release.py
@@ -15,12 +15,11 @@ This script will then:
     * Push these to Pypi.
 """
 
-import os
-import sys
-import shutil
 import importlib
+import os
+import shutil
 import subprocess
-
+import sys
 
 NAME = "jupyter_rfb"
 LIBNAME = NAME.replace("-", "_")

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup_args = dict(
         "numpy",
         "ipywidgets>=7.6.0",
     ],
+    python_requires=">=3.6",
     packages=find_packages(),
     zip_safe=False,
     cmdclass=cmdclass,


### PR DESCRIPTION
This lets pip know what the minimum version of python is that this package can be installed on and should save us in the future if users on old versions of python try to install new versions of the package.