### PR TITLE
Implement output widget for more reliable prints and errors

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -80,6 +80,23 @@ second. This is to avoid spamming the io and server process. The
 throttling applies to the resize, scroll, and pointer_move events.
 
 
+Exceptions and logging
+----------------------
+
+The ``handle_event()`` and ``get_frame()`` methods are called from a COM event
+and in an asyncio task, respectively. Under these circumstances,
+Jupyter Lab/Notebook may swallow exceptions and writes to stdout/stderr.
+See `issue #35 <https://github.com/vispy/jupyter_rfb/issues/35>`_ for details.
+
+In jupyter_rfb we take measures such that exceptions raised in
+either of these methods result in a traceback shown right above the
+widget. To ensure that calls to ``print()`` in these methods are also
+shown, use ``self.print()`` instead.
+
+Note that any other streaming to stdout and stderr (e.g. logging) may
+not become visible anywhere.
+
+
 Measuring statistics
 --------------------
 

--- a/examples/hello_world.ipynb
+++ b/examples/hello_world.ipynb
@@ -67,6 +67,7 @@
     "    def handle_event(self, event):\n",
     "        if event[\"event_type\"] == \"resize\":\n",
     "            self._size = event\n",
+    "            # print(event)  # uncomment to display the event\n",
     "        \n",
     "    def get_frame(self):\n",
     "        w, h, r = self._size[\"width\"], self._size[\"height\"], self._size[\"pixel_ratio\"]\n",

--- a/examples/hello_world.ipynb
+++ b/examples/hello_world.ipynb
@@ -67,7 +67,7 @@
     "    def handle_event(self, event):\n",
     "        if event[\"event_type\"] == \"resize\":\n",
     "            self._size = event\n",
-    "            # print(event)  # uncomment to display the event\n",
+    "            # self.print(event)  # uncomment to display the event\n",
     "        \n",
     "    def get_frame(self):\n",
     "        w, h, r = self._size[\"width\"], self._size[\"height\"], self._size[\"pixel_ratio\"]\n",

--- a/examples/ipywidgets_embed.ipynb
+++ b/examples/ipywidgets_embed.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f6315c1a",
+   "metadata": {},
+   "source": [
+    "# Embedding in an ipywidgets\n",
+    "\n",
+    "In this example we demonstrate embedding the ``RemoteFrameBuffer`` class inside a larger ipywidgets app."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb328d8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import ipywidgets\n",
+    "import jupyter_rfb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "627cd505",
+   "metadata": {},
+   "source": [
+    "Implement a simple RFB class, for the sake of the example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7691480a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class SimpleRFB(jupyter_rfb.RemoteFrameBuffer):\n",
+    "   \n",
+    "    green_value = 200\n",
+    "    \n",
+    "    def get_frame(self):\n",
+    "        a = np.zeros((100, 100, 3), np.uint8)\n",
+    "        a[20:-20,20:-20,1] = self.green_value\n",
+    "        return a   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91b9bcd3",
+   "metadata": {},
+   "source": [
+    "Compose a simple app:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45578bd6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slider = ipywidgets.IntSlider(min=50, max=255, value=200)\n",
+    "rfb = SimpleRFB()\n",
+    "\n",
+    "def on_slider_change(change):\n",
+    "    rfb.green_value = change[\"new\"]\n",
+    "    rfb.request_draw()\n",
+    "    \n",
+    "slider.observe(on_slider_change, names='value')\n",
+    "ipywidgets.HBox([rfb, slider])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7ee8d86-ab48-4e1d-8279-6bfbd53e5056",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/jupyter_rfb/widget.py
+++ b/jupyter_rfb/widget.py
@@ -116,8 +116,8 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
         # Setup an output widget, so that any prints and errors in our
         # callbacks are actually shown. We display the output in the cell-output
         # corresponding to the cell that instantiates the widget.
-        self._output_contex = OutputContext()
-        display(self._output_contex)
+        self._output_context = OutputContext()
+        display(self._output_context)
         # Init attributes for drawing
         self._rfb_draw_requested = False
         self._rfb_frame_index = 0
@@ -129,18 +129,15 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
         self.observe(self._rfb_schedule_maybe_draw, names=["frame_feedback"])
 
     def print(self, *args, **kwargs):
-        """Print to the widget's output area.
+        """Print to the widget's output area (For debugging purposes).
 
         In Jupyter, print calls that occur in a callback or an asyncio task
         may (depending on your version of the notebook/lab) not be shown.
         Inside ``get_frame()`` and ``handle_event()`` you can use this method
-        instead. Exceptions raised from these functions always show up
-        in the output area.
-
-        The signature of this method is fully compatible with the builtin print
-        function (except for the file argument).
+        instead. The signature of this method is fully compatible with
+        the builtin print function (except for the ``file`` argument).
         """
-        self._output_contex.print(*args, **kwargs)
+        self._output_context.print(*args, **kwargs)
 
     def close(self, *args, **kwargs):
         """Close all views of the widget and emit a close event."""
@@ -154,7 +151,7 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
         if "event_type" in content:
             if content["event_type"] == "resize":
                 self.request_draw()
-            with self._output_contex:
+            with self._output_context:
                 self.handle_event(content)
 
     # ---- drawing
@@ -188,7 +185,7 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
         frames_in_flight = self._rfb_frame_index - feedback.get("index", 0)
         if self._rfb_draw_requested and frames_in_flight < self.max_buffered_frames:
             self._rfb_draw_requested = False
-            with self._output_contex:
+            with self._output_context:
                 array = self.get_frame()
                 if array is not None:
                     self._rfb_send_frame(array)


### PR DESCRIPTION
Closes #35

Basically, this uses an `ipywidgets.Output` to show prints and errors. But we need to re-implement how it captures prints and errors to make it work reliably: `builtins.print` is briefly replaced, and errors passed directly.

The builtins trick feels a bit dirty ... but it works more reliable.

I should also add that the original behavior of the `Output` widget updates a trait in the `__enter__` making it unsuitable for use in `handle_event()` because it may be called *a lot*.