### PR TITLE
Prevent draws when there are no visible views

### DIFF
--- a/examples/visibility_check.ipynb
+++ b/examples/visibility_check.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "367f4c89",
    "metadata": {},
    "outputs": [],
@@ -24,39 +24,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "df8d3680",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3f8a21b821ca4fd5a624602e6e76feea",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "RFBOutputContext()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "54779414de044966a1a688e821f99917",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "RFBOutputContext()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "class ProgressBar(RemoteFrameBuffer):\n",
     "    \n",
@@ -107,76 +78,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "47cc2c4d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div class='initial-snapshot-c8d305c827d949a1ba721dbb1b304af2' style='position:relative;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlgAAABkCAIAAADVI9l0AAABkklEQVR42u3VAQkAIADEwO9fWluIsDvWYdvO2wDgL0YIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhAB0XdG1Zl+QPtaxAAAAAElFTkSuQmCC' style='width:600.0px;height:100.0px;' /><div style='position: absolute; top:0; left:0; padding:1px 3px; background: #777; color:#fff; font-size: 90%; font-family:sans-serif; '>initial snapshot</div></div>"
-      ],
-      "text/plain": [
-       "<jupyter_rfb._utils.Snapshot object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c8d305c827d949a1ba721dbb1b304af2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "AutoDrawWidget(css_height='100px', css_width='600px')"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "autodraw"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "b6e695ef",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div class='initial-snapshot-c8d305c827d949a1ba721dbb1b304af2' style='position:relative;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlgAAABkCAIAAADVI9l0AAACWUlEQVR42u3VAQkAIADEwO9fWlPIEO5Yh207nwQAT+SHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwQgcwGMictcaAU5qwAAAABJRU5ErkJggg==' style='width:600.0px;height:100.0px;' /><div style='position: absolute; top:0; left:0; padding:1px 3px; background: #777; color:#fff; font-size: 90%; font-family:sans-serif; '>initial snapshot</div></div>"
-      ],
-      "text/plain": [
-       "<jupyter_rfb._utils.Snapshot object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c8d305c827d949a1ba721dbb1b304af2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "AutoDrawWidget(css_height='100px', css_width='600px')"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "autodraw"
    ]
@@ -214,38 +129,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "45a05eb5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div class='initial-snapshot-705947e239a84cab848a66080bb16578' style='position:relative;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlgAAABkCAIAAADVI9l0AAABkklEQVR42u3VAQkAIADEwO9fWluIsDvWYdvZ0wDgL0YIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACEXTgiZl/BtbXuAAAAAElFTkSuQmCC' style='width:600.0px;height:100.0px;' /><div style='position: absolute; top:0; left:0; padding:1px 3px; background: #777; color:#fff; font-size: 90%; font-family:sans-serif; '>initial snapshot</div></div>"
-      ],
-      "text/plain": [
-       "<jupyter_rfb._utils.Snapshot object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "705947e239a84cab848a66080bb16578",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "IndicatorWidget(css_height='100px', css_width='600px')"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "indicator"
    ]

--- a/examples/visibility_check.ipynb
+++ b/examples/visibility_check.ipynb
@@ -1,0 +1,202 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3a254e70",
+   "metadata": {},
+   "source": [
+    "# Visibility check\n",
+    "\n",
+    "This notebook is to verify that widgets that are not visible do not perform any draws.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "367f4c89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import numpy as np\n",
+    "from jupyter_rfb import RemoteFrameBuffer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df8d3680",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ProgressBar(RemoteFrameBuffer):\n",
+    "    \n",
+    "    i = 0\n",
+    "    n = 32\n",
+    "    channel = 0\n",
+    "    callback = lambda *args: None\n",
+    "    \n",
+    "    def get_frame(self):\n",
+    "        self.callback()\n",
+    "        self.i += 1\n",
+    "        if self.i >= self.n:\n",
+    "            self.i = 0\n",
+    "        array = np.zeros((100, 600, 3), np.uint8)\n",
+    "        array[:,: int(array.shape[1] * (self.i + 1) / self.n), self.channel] = 255\n",
+    "        return array\n",
+    "\n",
+    "class AutoDrawWidget(ProgressBar):\n",
+    "    \n",
+    "    channel = 2  # blue\n",
+    "    \n",
+    "    def __init__(self, **kwargs):\n",
+    "        super().__init__(**kwargs)\n",
+    "        loop = asyncio.get_event_loop()\n",
+    "        loop.create_task(self._keep_at_it())\n",
+    "    \n",
+    "    async def _keep_at_it(self):\n",
+    "        while True:\n",
+    "            await asyncio.sleep(0.5)\n",
+    "            self.request_draw()\n",
+    "        \n",
+    "\n",
+    "class IndicatorWidget(ProgressBar):\n",
+    "    channel = 1  # green\n",
+    "\n",
+    "indicator = IndicatorWidget(css_width=\"600px\", css_height=\"100px\")\n",
+    "autodraw = AutoDrawWidget(css_width=\"600px\", css_height=\"100px\")\n",
+    "autodraw.callback = lambda *args: indicator.request_draw()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bc5e9ba",
+   "metadata": {},
+   "source": [
+    "We display a widget that automatically keeps progressing. Actually, we create two views of that widgets to make sure that this works for multiple views."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47cc2c4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autodraw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6e695ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autodraw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5120414",
+   "metadata": {},
+   "source": [
+    "Some empty space ...\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "Then we display an indicator widget, that only progresses when the widget above is drawing.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45a05eb5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indicator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8183275f",
+   "metadata": {},
+   "source": [
+    "More empty space so there is something to scroll down to ...\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    ".\n",
+    "\n",
+    "."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2052e248",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/visibility_check.ipynb
+++ b/examples/visibility_check.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "367f4c89",
    "metadata": {},
    "outputs": [],
@@ -24,10 +24,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "df8d3680",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3f8a21b821ca4fd5a624602e6e76feea",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "RFBOutputContext()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "54779414de044966a1a688e821f99917",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "RFBOutputContext()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "class ProgressBar(RemoteFrameBuffer):\n",
     "    \n",
@@ -78,20 +107,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "47cc2c4d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='initial-snapshot-c8d305c827d949a1ba721dbb1b304af2' style='position:relative;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlgAAABkCAIAAADVI9l0AAABkklEQVR42u3VAQkAIADEwO9fWluIsDvWYdvO2wDgL0YIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhAB0XdG1Zl+QPtaxAAAAAElFTkSuQmCC' style='width:600.0px;height:100.0px;' /><div style='position: absolute; top:0; left:0; padding:1px 3px; background: #777; color:#fff; font-size: 90%; font-family:sans-serif; '>initial snapshot</div></div>"
+      ],
+      "text/plain": [
+       "<jupyter_rfb._utils.Snapshot object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c8d305c827d949a1ba721dbb1b304af2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AutoDrawWidget(css_height='100px', css_width='600px')"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "autodraw"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "b6e695ef",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='initial-snapshot-c8d305c827d949a1ba721dbb1b304af2' style='position:relative;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlgAAABkCAIAAADVI9l0AAACWUlEQVR42u3VAQkAIADEwO9fWlPIEO5Yh207nwQAT+SHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwSglB/OCAEo5YczQgBK+eGMEIBSfjgjBKCUH84IASjlhzNCAEr54YwQgFJ+OCMEoJQfzggBKOWHM0IASvnhjBCAUn44IwQgcwGMictcaAU5qwAAAABJRU5ErkJggg==' style='width:600.0px;height:100.0px;' /><div style='position: absolute; top:0; left:0; padding:1px 3px; background: #777; color:#fff; font-size: 90%; font-family:sans-serif; '>initial snapshot</div></div>"
+      ],
+      "text/plain": [
+       "<jupyter_rfb._utils.Snapshot object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c8d305c827d949a1ba721dbb1b304af2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AutoDrawWidget(css_height='100px', css_width='600px')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "autodraw"
    ]
@@ -129,10 +214,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "45a05eb5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='initial-snapshot-705947e239a84cab848a66080bb16578' style='position:relative;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlgAAABkCAIAAADVI9l0AAABkklEQVR42u3VAQkAIADEwO9fWluIsDvWYdvZ0wDgL0YIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACkGSEAaUYIQJoRApBmhACEXTgiZl/BtbXuAAAAAElFTkSuQmCC' style='width:600.0px;height:100.0px;' /><div style='position: absolute; top:0; left:0; padding:1px 3px; background: #777; color:#fff; font-size: 90%; font-family:sans-serif; '>initial snapshot</div></div>"
+      ],
+      "text/plain": [
+       "<jupyter_rfb._utils.Snapshot object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "705947e239a84cab848a66080bb16578",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IndicatorWidget(css_height='100px', css_width='600px')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "indicator"
    ]

--- a/examples/visibility_check.ipynb
+++ b/examples/visibility_check.ipynb
@@ -168,14 +168,6 @@
     "\n",
     "."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2052e248",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/js/lib/widget.js
+++ b/js/lib/widget.js
@@ -56,7 +56,6 @@ var RemoteFrameBufferModel = widgets.DOMWidgetModel.extend({
         };
         // Keep track of whether any objects are shown
         this._intersection_observer = new IntersectionObserver(this._intersection_calback.bind(this));
-        this._visible_view_count = -1;
         // Start the animation loop
         this._img_update_pending = false;
         this._request_animation_frame();
@@ -100,9 +99,9 @@ var RemoteFrameBufferModel = widgets.DOMWidgetModel.extend({
             if (img._is_visible) { count += 1; }
         }
         // If the state changed, update our flag
-        if (count != this._visible_view_count) {
-            this._visible_view_count = count;
-            this.set('has_visible_views', count > 0);
+        let has_visible_views = count > 0; 
+        if (has_visible_views != this.get("has_visible_views")) {
+            this.set('has_visible_views', has_visible_views);
             this.save_changes();
         }
     },

--- a/js/lib/widget.js
+++ b/js/lib/widget.js
@@ -55,7 +55,7 @@ var RemoteFrameBufferModel = widgets.DOMWidgetModel.extend({
             timestamp: 0,
         };
         // Keep track of whether any objects are shown
-        this._intersection_observer = new IntersectionObserver(this._intersection_calback.bind(this));
+        this._intersection_observer = new IntersectionObserver(this._intersection_callback.bind(this));
         // Start the animation loop
         this._img_update_pending = false;
         this._request_animation_frame();
@@ -88,7 +88,7 @@ var RemoteFrameBufferModel = widgets.DOMWidgetModel.extend({
         }
     },
 
-    _intersection_calback: function(entries, observer) {
+    _intersection_callback: function(entries, observer) {
         // Set visibility of changed img elements
         for (let entry of entries) {
             entry.target._is_visible = entry.isIntersecting;

--- a/js/lib/widget.js
+++ b/js/lib/widget.js
@@ -56,7 +56,7 @@ var RemoteFrameBufferModel = widgets.DOMWidgetModel.extend({
         };
         // Keep track of whether any objects are shown
         this._intersection_observer = new IntersectionObserver(this._intersection_calback.bind(this));
-        this._visible_view_count = 0;
+        this._visible_view_count = -1;
         // Start the animation loop
         this._img_update_pending = false;
         this._request_animation_frame();

--- a/jupyter_rfb/widget.py
+++ b/jupyter_rfb/widget.py
@@ -241,14 +241,15 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
         feedback = self.frame_feedback
         # Update stats
         self._rfb_update_stats(feedback)
-        # Determine whether we should perform a draw
+        # Determine whether we should perform a draw: a draw was requested, and
+        # the client is ready for a new frame, and the client widget is visible.
         frames_in_flight = self._rfb_frame_index - feedback.get("index", 0)
         should_draw = (
             self._rfb_draw_requested
             and frames_in_flight < self.max_buffered_frames
             and self.has_visible_views
         )
-        # Then do  the draw, if we should
+        # Do the draw if we should.
         if should_draw:
             self._rfb_draw_requested = False
             with self._output_context:

--- a/jupyter_rfb/widget.py
+++ b/jupyter_rfb/widget.py
@@ -65,11 +65,11 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
 
     # Widget specific traits
     frame_feedback = Dict({}).tag(sync=True)
+    has_visible_views = Bool(False).tag(sync=True)
     max_buffered_frames = Int(2, min=1)
     css_width = Unicode("500px").tag(sync=True)
     css_height = Unicode("300px").tag(sync=True)
     resizable = Bool(True).tag(sync=True)
-    has_visible_views = Bool(False).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -265,7 +265,7 @@ def test_has_visible_views():
     fs.frame_feedback["localtime"] = time.time()
 
     fs.has_visible_views = False
-    for i in range(3):
+    for _ in range(3):
         fs.trigger(True)
         assert len(fs.msgs) == 1
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -22,6 +22,7 @@ class MyRFB(RemoteFrameBuffer):
     def __init__(self):
         super().__init__()
         self.frame_feedback = {}
+        self.has_visible_views = True
         self.msgs = []
 
     def send(self, msg):
@@ -248,6 +249,29 @@ def test_requesting_draws():
     w._rfb_draw_requested = False
     w._rfb_handle_msg(None, {"event_type": "resize"}, [])
     assert w._rfb_draw_requested
+
+
+def test_has_visible_views():
+    """Test that no draws are performed if there are no visible views."""
+
+    fs = MyRFB()
+
+    fs.trigger(True)
+    assert len(fs.msgs) == 1
+
+    # Flush
+    fs.frame_feedback["index"] = 1
+    fs.frame_feedback["timestamp"] = fs.msgs[-1]["timestamp"]
+    fs.frame_feedback["localtime"] = time.time()
+
+    fs.has_visible_views = False
+    for i in range(3):
+        fs.trigger(True)
+        assert len(fs.msgs) == 1
+
+    fs.has_visible_views = True
+    fs.trigger(True)
+    assert len(fs.msgs) == 2
 
 
 def test_automatic_events():


### PR DESCRIPTION
Closes #12

* In JS we use the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to keep track of the visibility of the widget views. 
* This observer is updated/reset whenever a view is newly created or removed.
* With the help of this observer we set the new `has_visible_views` trait.
* In Python we only actually draw if `has_visible_views` is true.

Also adds a notebook to test this behavior.

This can be a major performance boost in cases where you have multiple widgets that are continually updating, because these share the available IO and CPU resources. With this PR, when one widget goes out of visual scope, the others become faster.