### PR TITLE
Apply JPEG encoding for better performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,10 @@ jobs:
         shell: bash
         run: |
             python -m pip install --upgrade pip
-            pip install jupyter_packaging
+            pip install -U jupyter_packaging
             pip install -U ipywidgets numpy tornado
-            pip install pytest
+            pip install -U simplejpeg pillow
+            pip install -U pytest
             pip install .
             rm -rf ./jupyter_rfb ./build ./egg-info
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,44 +8,55 @@ on:
 
 
 jobs:
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        shell: bash
+        run: |
+            python -m pip install --upgrade pip
+            pip install black flake8 flake8-docstrings flake8-bugbear flake8-debugger
+      - name: Black
+        shell: bash
+        run: black --check .
+      - name: Flake
+        shell: bash
+        run: flake8 .
+
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - name: Lint
-            os: ubuntu-latest
-            pyversion: '3.7'
-            dolint: 1
           - name: Linux py36
             os: ubuntu-latest
             pyversion: '3.6'
-            tests: 1
           - name: Linux py37
             os: ubuntu-latest
             pyversion: '3.7'
-            tests: 1
           - name: Linux py38
             os: ubuntu-latest
             pyversion: '3.8'
-            tests: 1
           - name: Linux py39
             os: ubuntu-latest
             pyversion: '3.9'
-            tests: 1
           - name: Linux pypy3
             os: ubuntu-latest
             pyversion: 'pypy3'
-            tests: 1
           - name: Windows py38
             os: windows-latest
             pyversion: '3.8'
-            tests: 1
           - name: MacOS py38
             os: macos-latest
             pyversion: '3.8'
-            tests: 1
 
     steps:
 
@@ -58,31 +69,14 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - name: Install dependencies (lint and docs)
-        if: matrix.dolint == 1
+      - name: Install dependencies
         shell: bash
         run: |
             python -m pip install --upgrade pip
-            pip install black flake8 flake8-docstrings flake8-bugbear flake8-debugger
-      - name: Install dependencies (unit tests)
-        if: matrix.tests == 1
-        shell: bash
-        run: |
-            python -m pip install --upgrade pip
-            pip install -U jupyter_packaging
-            pip install -U ipywidgets numpy tornado
-            pip install -U simplejpeg pillow
-            pip install -U pytest
+            pip install -U jupyter_packaging pytest simplejpeg pillow
             pip install .
             rm -rf ./jupyter_rfb ./build ./egg-info
-      - name: Lint
-        if: matrix.dolint == 1
-        shell: bash
-        run: |
-            black --check .
-            flake8 .
       - name: Test with pytest
-        if: matrix.tests == 1
         shell: bash
         run: |
             python -c "import sys; print(sys.version, '\n', sys.prefix)";

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ node_modules/
 docs/site/
 docs/_build
 docs/examples/*.ipynb
+.coverage
+htmlcov/
 
 # Compiled javascript
 jupyter_rfb/nbextension/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To install use pip:
 
     $ pip install jupyter_rfb
 
+For better performance, also ``pip install simplejpeg`` or ``pip install pillow``.
 On older versions of Jupyter notebook/lab an extra step might be needed
 to enable the widget.
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -16,6 +16,8 @@ Or to install into a conda environment:
 
     conda install -c conda-forge jupyter-rfb
 
+For better performance, also install ``simplejpeg`` or ``pillow``.
+
 If you plan to hack on this library, see the :doc:`contributor guide <contributing>`
 for a dev installation and more.
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -163,7 +163,10 @@ Performance tips
 
 The framerate that can be obtained depends on a number of factors:
 
-* The size of a frame: larger frames generally take longer to encode.
-* The entropy (information density) of a frame: random data takes longer to compress.
-* How many widgets are drawing simultaneously (they use the same communication channel).
-* How much other work your CPU does (image compression is CPU-bound).
+* The size of a frame: smaller frames generally encode faster and result
+  in smaller blobs, causing less strain on both CPU and IO.
+* How many widgets are drawing simultaneously: they use the same communication channel.
+* The ``widget.quality`` trait: lower quality results in faster encoding and smaller blobs.
+* When using lossless images (``widget.quality == 100``), the entropy
+  (information density) of a frame also matters, because for PNG, high entropy
+  data takes longer to compress and results in larger blobs.

--- a/js/lib/widget.js
+++ b/js/lib/widget.js
@@ -244,7 +244,7 @@ var RemoteFrameBufferView = widgets.DOMWidgetView.extend({
                 if (Object.keys(that._pointers).length > 0) { return; }
             }
             let event = create_pointer_event(that.img, e, that._pointers, 'pointer_move');
-            that.send_throttled(event, 50);
+            that.send_throttled(event, 20);
         });
 
         // Click events are not pointer events. Not sure if we need click events. It seems to make
@@ -326,7 +326,7 @@ var RemoteFrameBufferView = widgets.DOMWidgetView.extend({
         let event_type = msg.event_type || '';
         let func = this._throttlers[event_type];
         if (func === undefined) {
-            func = throttled(this.send, wait || 100);
+            func = throttled(this.send, wait || 50);
             this._throttlers[event_type] = func;
         }
         func.call(this, msg);

--- a/jupyter_rfb/_jpg.py
+++ b/jupyter_rfb/_jpg.py
@@ -1,0 +1,128 @@
+import io
+import importlib
+
+
+class JpegEncoder:
+    """Base JPEG encoder class.
+
+    Subclasses must import their dependencies in their __init__,
+    and implement the _encode() method.
+    """
+
+    def encode(self, array, quality):
+        """Encode the array, returning bytes."""
+
+        quality = int(quality)
+
+        # Check types
+        if hasattr(array, "shape") and hasattr(array, "dtype"):
+            if array.dtype != "uint8":
+                raise ValueError("Image array to convert to JPEG must be uint8")
+            original_shape = shape = array.shape
+        else:
+            raise ValueError(
+                f"Invalid type for array, need ndarray-like, got {type(array)}"
+            )
+
+        # Check shape
+        if len(shape) == 2:
+            shape = shape + (1,)
+            array = array.reshape(shape)
+        if not (len(shape) == 3 and shape[2] in (1, 3)):
+            raise ValueError(f"Unexpected image shape: {original_shape}")
+
+        return self._encode(array, quality)
+
+    def _encode(self, array, quality):
+        raise NotImplementedError()
+
+
+class StubJpegEncoder(JpegEncoder):
+    """A stub encoder that returns None."""
+
+    def _encode(self, array, quality):
+        return None
+
+
+class SimpleJpegEncoder(JpegEncoder):
+    """A JPEG encoder using the simplejpeg library."""
+
+    def __init__(self):
+        self.simplejpeg = importlib.import_module("simplejpeg")
+
+    def _encode(self, array, quality):
+
+        # Simplejpeg requires contiguous data
+        if not array.flags.c_contiguous:
+            array = array.copy()
+
+        # Get appropriate colorspace
+        nchannels = array.shape[2]
+        if nchannels == 1:
+            colorspace = "GRAY"
+            colorsubsampling = "Gray"
+        elif nchannels == 3:
+            colorspace = "RGB"
+            colorsubsampling = "444"
+        elif nchannels == 4:  # no-cover
+            # No alpha in JPEG - transparent pixels become black
+            colorspace = "RGBA"
+            colorsubsampling = "444"
+
+        # Encode!
+        return self.simplejpeg.encode_jpeg(
+            array,
+            quality=quality,
+            colorspace=colorspace,
+            colorsubsampling=colorsubsampling,
+            fastdct=True,
+        )
+
+
+class PillowJpegEncoder(JpegEncoder):
+    """A JPEG encoder using the Pillow library."""
+
+    def __init__(self):
+        self.pillow = importlib.import_module("PIL.Image")
+
+    def _encode(self, array, quality):
+
+        # Pillow likes grayscale as an NxM array (not NxMx1)
+        if len(array.shape) == 3 and array.shape[2] == 1:
+            array = array.reshape(array.shape[:-1])
+
+        # Encode!
+        img_pil = self.pillow.fromarray(array)
+        f = io.BytesIO()
+        img_pil.save(f, format="JPEG", quality=quality)
+        return f.getvalue()
+
+
+def select_encoder():
+    """Select an encoder."""
+
+    for cls in [
+        SimpleJpegEncoder,  # simplejpeg is fast and lean
+        PillowJpegEncoder,  # pillow is commonly available
+    ]:
+        try:
+            return cls()
+        except Exception:
+            continue
+    else:
+        return StubJpegEncoder()  # if all else fails
+
+
+encoder = select_encoder()
+
+
+def array2jpg(array, quality=90):
+    """Create a JPEG image from a numpy array, with the given quality (percentage).
+
+    The provided array's shape must be either NxM (grayscale), NxMx1 (grayscale),
+    or NxMx3 (RGB).
+
+    The encoding is performed be one of multiple possible backends. If
+    no backend is available, None is returned.
+    """
+    return encoder.encode(array, quality)

--- a/jupyter_rfb/_jpg.py
+++ b/jupyter_rfb/_jpg.py
@@ -1,5 +1,4 @@
 import io
-import importlib
 
 
 class JpegEncoder:
@@ -48,7 +47,9 @@ class SimpleJpegEncoder(JpegEncoder):
     """A JPEG encoder using the simplejpeg library."""
 
     def __init__(self):
-        self.simplejpeg = importlib.import_module("simplejpeg")
+        import simplejpeg
+
+        self.simplejpeg = simplejpeg
 
     def _encode(self, array, quality):
 
@@ -83,7 +84,9 @@ class PillowJpegEncoder(JpegEncoder):
     """A JPEG encoder using the Pillow library."""
 
     def __init__(self):
-        self.pillow = importlib.import_module("PIL.Image")
+        import PIL.Image
+
+        self.pillow = PIL.Image
 
     def _encode(self, array, quality):
 

--- a/jupyter_rfb/_jpg.py
+++ b/jupyter_rfb/_jpg.py
@@ -107,7 +107,7 @@ def select_encoder():
     ]:
         try:
             return cls()
-        except Exception:
+        except ImportError:
             continue
     else:
         return StubJpegEncoder()  # if all else fails

--- a/jupyter_rfb/_png.py
+++ b/jupyter_rfb/_png.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 def array2png(array, file=None):
-    """Create a png image from a numpy array.
+    """Create a PNG image from a numpy array.
 
     The written image is in RGB or RGBA format, with 8 bit precision,
     zlib-compressed, without interlacing.
@@ -18,7 +18,7 @@ def array2png(array, file=None):
     # Check types
     if hasattr(array, "shape") and hasattr(array, "dtype"):
         if array.dtype != "uint8":
-            raise TypeError("Image array to convert to PNG must be uint8")
+            raise ValueError("Image array to convert to PNG must be uint8")
         original_shape = shape = array.shape
     else:
         raise ValueError(

--- a/jupyter_rfb/_utils.py
+++ b/jupyter_rfb/_utils.py
@@ -11,14 +11,16 @@ from ._jpg import array2jpg
 
 
 _original_print = builtins.print
+_warned_png = False
 
 
-def array2compressed(array, quality=90):
+def array2compressed(array, quality=90, logfunc=print):
     """Convert the given image (a numpy array) as a compressed array.
 
     If the quality is 100, a PNG is returned. Otherwise, JPEG is
     preferred and PNG is used as a fallback. Returns (preamble, bytes).
     """
+    global _warned_png
 
     # Drop alpha channel if there is one
     if len(array.shape) == 3 and array.shape[2] == 4:
@@ -33,6 +35,13 @@ def array2compressed(array, quality=90):
         if result is None:
             preamble = "data:image/png;base64,"
             result = array2png(array)
+            # Issue png warning
+            if not _warned_png:
+                _warned_png = True
+                logfunc(
+                    "Warning: No JPEG encoder found, using PNG instead. "
+                    + "Install simplejpeg or pillow for better performance."
+                )
 
     return preamble, result
 

--- a/jupyter_rfb/_utils.py
+++ b/jupyter_rfb/_utils.py
@@ -7,8 +7,34 @@ from IPython.display import DisplayObject
 import ipywidgets
 
 from ._png import array2png
+from ._jpg import array2jpg
+
 
 _original_print = builtins.print
+
+
+def array2compressed(array, quality=90):
+    """Convert the given image (a numpy array) as a compressed array.
+
+    If the quality is 100, a PNG is returned. Otherwise, JPEG is
+    preferred and PNG is used as a fallback. Returns (preamble, bytes).
+    """
+
+    # Drop alpha channel if there is one
+    if len(array.shape) == 3 and array.shape[2] == 4:
+        array = array[:, :, :3]
+
+    if quality >= 100:
+        preamble = "data:image/png;base64,"
+        result = array2png(array)
+    else:
+        preamble = "data:image/jpeg;base64,"
+        result = array2jpg(array, quality)
+        if result is None:
+            preamble = "data:image/png;base64,"
+            result = array2png(array)
+
+    return preamble, result
 
 
 class RFBOutputContext(ipywidgets.Output):

--- a/jupyter_rfb/_utils.py
+++ b/jupyter_rfb/_utils.py
@@ -11,16 +11,14 @@ from ._jpg import array2jpg
 
 
 _original_print = builtins.print
-_warned_png = False
 
 
-def array2compressed(array, quality=90, logfunc=print):
+def array2compressed(array, quality=90):
     """Convert the given image (a numpy array) as a compressed array.
 
     If the quality is 100, a PNG is returned. Otherwise, JPEG is
     preferred and PNG is used as a fallback. Returns (preamble, bytes).
     """
-    global _warned_png
 
     # Drop alpha channel if there is one
     if len(array.shape) == 3 and array.shape[2] == 4:
@@ -35,13 +33,6 @@ def array2compressed(array, quality=90, logfunc=print):
         if result is None:
             preamble = "data:image/png;base64,"
             result = array2png(array)
-            # Issue png warning
-            if not _warned_png:
-                _warned_png = True
-                logfunc(
-                    "Warning: No JPEG encoder found, using PNG instead. "
-                    + "Install simplejpeg or pillow for better performance."
-                )
 
     return preamble, result
 

--- a/jupyter_rfb/widget.py
+++ b/jupyter_rfb/widget.py
@@ -39,6 +39,10 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
     * *css_width*: the logical width of the frame as a CSS string. Default '500px'.
     * *css_height*: the logical height of the frame as a CSS string. Default '300px'.
     * *resizable*: whether the frame can be manually resized. Default True.
+    * *quality*: the quality of the JPEG encoding during interaction/animation
+      as a number between 1 and 100. Default 80. Set to lower numbers for more
+      performance on slow connections. Set to 100 for lossless (PNG),
+      but note that each interaction is ended with a lossless image anyway.
     * *max_buffered_frames*: the number of frames that is allowed to be "in-flight",
       i.e. sent, but not yet confirmed by the client. Default 2. Higher values
       may result in a higher FPS at the cost of introducing lag.

--- a/jupyter_rfb/widget.py
+++ b/jupyter_rfb/widget.py
@@ -21,8 +21,7 @@ import numpy as np
 from IPython.display import display
 from traitlets import Bool, Dict, Int, Unicode
 
-from ._png import array2png
-from ._utils import RFBOutputContext, Snapshot
+from ._utils import array2compressed, RFBOutputContext, Snapshot
 
 
 @ipywidgets.register
@@ -67,6 +66,7 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
     frame_feedback = Dict({}).tag(sync=True)
     has_visible_views = Bool(False).tag(sync=True)
     max_buffered_frames = Int(2, min=1)
+    quality = Int(80, min=1, max=100)
     css_width = Unicode("500px").tag(sync=True)
     css_height = Unicode("300px").tag(sync=True)
     resizable = Bool(True).tag(sync=True)
@@ -262,12 +262,11 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
         self._rfb_frame_index += 1
         timestamp = time.time()
 
-        # Turn array into a based64-encoded PNG
+        # Turn array into a based64-encoded JPEG or PNG
         t1 = time.perf_counter()
-        png_data = array2png(array)
+        preamble, data = array2compressed(array, self.quality, self.print)
         t2 = time.perf_counter()
-        preamble = "data:image/png;base64,"
-        src = preamble + encodebytes(png_data).decode()
+        src = preamble + encodebytes(data).decode()
         t3 = time.perf_counter()
 
         # Stats

--- a/jupyter_rfb/widget.py
+++ b/jupyter_rfb/widget.py
@@ -41,8 +41,9 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
     * *resizable*: whether the frame can be manually resized. Default True.
     * *quality*: the quality of the JPEG encoding during interaction/animation
       as a number between 1 and 100. Default 80. Set to lower numbers for more
-      performance on slow connections. Set to 100 for lossless (PNG),
-      but note that each interaction is ended with a lossless image anyway.
+      performance on slow connections. Note that each interaction is ended with a
+      lossless image (PNG). If set to 100 or if JPEG encoding isn't possible (missing
+      pillow or simplejpeg dependencies), then lossless PNGs will always be sent.
     * *max_buffered_frames*: the number of frames that is allowed to be "in-flight",
       i.e. sent, but not yet confirmed by the client. Default 2. Higher values
       may result in a higher FPS at the cost of introducing lag.

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,10 @@ skip_gitignore = true
 force_to_top = true
 default_section = THIRDPARTY
 known_first_party = jupyter_rfb
+
+[coverage:report]
+exclude_lines =
+    # Note that these are reg exp, and that we need to re-enable the standard pragma
+    pragma: no cover
+    raise NotImplementedError
+    no-cover

--- a/tests/test_jpg.py
+++ b/tests/test_jpg.py
@@ -99,6 +99,11 @@ def _perform_error_checks(encoder):
         encoder.encode(get_random_im(10, 10, 3).astype(np.float32), 90)
 
 
+def raise_importerror():
+    """Raise an import error (flake forces me to write this docstring)."""
+    raise ImportError()
+
+
 def test_select_encoder():
     """Test the JPEG encoder selection mechanism."""
 
@@ -109,8 +114,8 @@ def test_select_encoder():
     simple_init = SimpleJpegEncoder.__init__
     pillow_init = PillowJpegEncoder.__init__
     try:
-        SimpleJpegEncoder.__init__ = lambda self: 1 / 0
-        PillowJpegEncoder.__init__ = lambda self: 1 / 0
+        SimpleJpegEncoder.__init__ = lambda self: raise_importerror()
+        PillowJpegEncoder.__init__ = lambda self: raise_importerror()
 
         encoder = select_encoder()
         assert not isinstance(encoder, (SimpleJpegEncoder, PillowJpegEncoder))

--- a/tests/test_jpg.py
+++ b/tests/test_jpg.py
@@ -1,0 +1,124 @@
+"""Test jpg module."""
+
+import numpy as np
+from pytest import raises
+
+from jupyter_rfb._jpg import (
+    array2jpg,
+    select_encoder,
+    SimpleJpegEncoder,
+    PillowJpegEncoder,
+)
+
+
+def get_random_im(*shape):
+    """Get a random image."""
+    return np.random.randint(0, 255, shape).astype(np.uint8)
+
+
+def test_array2jpg():
+    """Tests for array2jpg function."""
+
+    im = get_random_im(100, 100, 3)
+    bb1 = array2jpg(im)  # has default quality
+    bb2 = array2jpg(im, 20)
+    assert isinstance(bb1, bytes)
+    assert len(bb2) < len(bb1)
+
+
+def test_simplejpeg_jpeg_encoder():
+    """Test the simplejpeg encoder."""
+    encoder = SimpleJpegEncoder()
+    _perform_checks(encoder)
+    _perform_error_checks(encoder)
+
+
+def test_pillow_jpeg_encoder():
+    """Test the pillow encoder."""
+    encoder = PillowJpegEncoder()
+    _perform_checks(encoder)
+    _perform_error_checks(encoder)
+
+
+def _perform_checks(encoder):
+
+    # RGB
+    im = get_random_im(100, 100, 3)
+    bb1 = encoder.encode(im, 90)
+    bb2 = encoder.encode(im, 20)
+    assert isinstance(bb1, bytes)
+    assert len(bb2) < len(bb1)
+
+    # RGB non-contiguous
+    im = get_random_im(100, 100, 3)
+    bb1 = encoder.encode(im[20:-20, 20:-20, :], 90)
+    bb2 = encoder.encode(im[20:-20, 20:-20, :], 20)
+    assert isinstance(bb1, bytes)
+    assert len(bb2) < len(bb1)
+
+    # Gray1
+    im = get_random_im(100, 100)
+    bb1 = encoder.encode(im, 90)
+    bb2 = encoder.encode(im, 20)
+    assert isinstance(bb1, bytes)
+    assert len(bb2) < len(bb1)
+
+    # Gray2
+    im = get_random_im(100, 100, 1)
+    bb1 = encoder.encode(im, 90)
+    bb2 = encoder.encode(im, 20)
+    assert isinstance(bb1, bytes)
+    assert len(bb2) < len(bb1)
+
+    # Gray non-contiguous
+    im = get_random_im(100, 100)
+    bb1 = encoder.encode(im[20:-20, 20:-20], 90)
+    bb2 = encoder.encode(im[20:-20, 20:-20], 20)
+    assert isinstance(bb1, bytes)
+    assert len(bb2) < len(bb1)
+
+
+def _perform_error_checks(encoder):
+
+    # JUst to verify that this is ok
+    encoder.encode(get_random_im(10, 10, 3), 90)
+
+    with raises(ValueError):  # not a numpy array
+        encoder.encode([1, 2, 3, 4], 90)
+
+    with raises(ValueError):  # not a numpy array
+        encoder.encode(b"1234", 90)
+
+    with raises(ValueError):  # NxMx2?
+        encoder.encode(get_random_im(10, 10, 2), 90)
+
+    with raises(ValueError):  # NxMx4?
+        encoder.encode(get_random_im(10, 10, 4), 90)
+
+    with raises(ValueError):
+        encoder.encode(get_random_im(10, 10, 3).astype(np.float32), 90)
+
+
+def test_select_encoder():
+    """Test the JPEG encoder selection mechanism."""
+
+    encoder = select_encoder()
+    assert isinstance(encoder, (SimpleJpegEncoder, PillowJpegEncoder))
+
+    # Sabotage
+    simple_init = SimpleJpegEncoder.__init__
+    pillow_init = PillowJpegEncoder.__init__
+    try:
+        SimpleJpegEncoder.__init__ = lambda self: 1 / 0
+        PillowJpegEncoder.__init__ = lambda self: 1 / 0
+
+        encoder = select_encoder()
+        assert not isinstance(encoder, (SimpleJpegEncoder, PillowJpegEncoder))
+
+        # Without a valid encoder, we get the stub encoder
+        result = encoder.encode(get_random_im(10, 10, 3), 90)
+        assert result is None
+
+    finally:
+        SimpleJpegEncoder.__init__ = simple_init
+        PillowJpegEncoder.__init__ = pillow_init

--- a/tests/test_png.py
+++ b/tests/test_png.py
@@ -86,6 +86,9 @@ def test_writing():
     b1_check = array2png(im1.reshape(shape1[0], shape1[1], 1))
     assert b1_check == b1
 
+    # Test noncontiguus data
+    array2png(im3[1:-1, 1:-1, :])
+
 
 def test_writing_failures():
     """Test that errors are raised when needed."""
@@ -101,3 +104,6 @@ def test_writing_failures():
 
     with raises(ValueError):
         array2png(im4.reshape(-1, -1, 8))
+
+    with raises(ValueError):
+        array2png(im4.astype(np.float32))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,63 @@
 """Test the things in the utils module."""
 
 import numpy as np
-from jupyter_rfb._utils import RFBOutputContext, Snapshot
+from jupyter_rfb._utils import array2compressed, RFBOutputContext, Snapshot
+from jupyter_rfb import _jpg
+
+
+def test_array2compressed():
+    """Test the array2compressed function."""
+
+    # This test assumes that a JPEG encoder is available
+
+    im = np.random.randint(0, 255, (100, 100, 3)).astype(np.uint8)
+
+    # Basic check
+    preamble, bb = array2compressed(im)
+    assert isinstance(preamble, str)
+    assert isinstance(bb, bytes)
+    assert "jpeg" in preamble and "png" not in preamble
+
+    # Check compression
+    preamble1, bb1 = array2compressed(im, 90)
+    preamble2, bb2 = array2compressed(im, 30)
+    assert len(bb2) < len(bb1)
+
+    # Check quality 100
+    preamble3, bb3 = array2compressed(im, 100)
+    assert len(bb3) > len(bb1)
+
+    assert "jpeg" in preamble1 and "png" not in preamble1
+    assert "jpeg" in preamble2 and "png" not in preamble1
+    assert "png" in preamble3 and "jpeg" not in preamble3
+
+    # Check that RGBA is made RGB
+    im4 = np.random.randint(0, 255, (100, 100, 4)).astype(np.uint8)
+    im3 = im4[:, :, :3]
+    _, bb1 = array2compressed(im4, 90)
+    _, bb2 = array2compressed(im3, 90)
+    assert bb1 == bb2
+
+    # Also for PNG mode
+    _, bb1 = array2compressed(im4, 100)
+    _, bb2 = array2compressed(im3, 100)
+    assert bb1 == bb2
+
+    # Check fallback - disable JPEG encoding, we get PNG
+    _jpg.encoder = _jpg.StubJpegEncoder()
+    try:
+
+        preamble, bb = array2compressed(im)
+        assert isinstance(preamble, str)
+        assert isinstance(bb, bytes)
+        assert "png" in preamble and "jpeg" not in preamble
+
+    finally:
+        _jpg.encoder = _jpg.select_encoder()
+
+    # Should be back to normal now
+    preamble, bb = array2compressed(im)
+    assert "jpeg" in preamble and "png" not in preamble
 
 
 class StubRFBOutputContext(RFBOutputContext):


### PR DESCRIPTION
* [x] Implement JPEG encoding based on simplejpeg and Pillow.
* [x] Tests.
* [x] Add optional dependencies and dev dependencies.
* [x] Make widget use encoding.
* [x] Always end with a PNG. 
* [x] Decrease throttle-time in JS a bit.
* [x] Document (and maybe rename?) new `quality` trait.


----

This example, but with a canvas size of 800x600, renders 5 FPS before this PR. But with JPEG encoding it renders at 28 FPS.
![cube1](https://user-images.githubusercontent.com/3015475/135281050-aa8224c2-dd65-4a63-8f63-56570f5635a4.gif)


This Vispy example, at 800x600 renders at 30+ FPS (20 FPS with lossless (PNG)),
![spheres1](https://user-images.githubusercontent.com/3015475/135281728-5d183a01-49cc-4638-8623-570caca06169.gif)

