### PR TITLE
add dependencies required for tests to contrib docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -51,6 +51,12 @@ Install developer tools
 
     $ pip install pytest black flake8 flake8-docstrings flake8-bugbear
 
+Install dependencies required for tests
+---------------------------------------
+
+.. code-block::
+
+   $ pip install pillow simplejpeg
 
 Automated tools
 ---------------


### PR DESCRIPTION
`pillow` and `simplejpeg` are required to run the tests, added to contribution instructions, maybe better to use an `install_extras` for development? 