### PR TITLE
drop python 3.7 and 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,6 @@ jobs:
       matrix:
         include:
           # Python versions
-          - name: Linux py37
-            os: ubuntu-latest
-            pyversion: '3.7'
-          - name: Linux py38
-            os: ubuntu-latest
-            pyversion: '3.8'
           - name: Linux py39
             os: ubuntu-latest
             pyversion: '3.9'

--- a/jupyter_rfb/_version.py
+++ b/jupyter_rfb/_version.py
@@ -1,5 +1,5 @@
 # Module version
-version_info = (0, 3, 3, "final", 0)
+version_info = (0, 4, 0, "final", 0)
 
 # Module version stage suffix map
 _specifier_ = {"alpha": "a", "beta": "b", "candidate": "rc", "final": ""}

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup_args = dict(
         "ipywidgets>=7.6.0,<9",
         "jupyterlab-widgets",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     packages=find_packages(),
     zip_safe=False,
     cmdclass=cmdclass,


### PR DESCRIPTION
The latest ipython drops support for python 3.8 as per NEP 29: https://ipython.readthedocs.io/en/stable/whatsnew/version8.html#ipython-8-13

I thought a version bump would be appropriate too since it's a python version and not dep version change, but feel free to change :)