### PR TITLE
colab compatibility 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/setup-node
         with:
           node-version: 18
+      - name: publish npm
         run: |
           cd js
           npm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,4 +35,7 @@ jobs:
       - name: publish npm
         run: |
           cd js
-          yarn publish
+          yarn publish --non-interactive
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,18 +12,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-python@v3
-
-      - name: build python package
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
-      - run: |
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
           python -m pip install --upgrade pip
-          pip install build twine
-          python -m build
-
+          pip install build
+      - name: Build package
+        run: python -m build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,4 +35,4 @@ jobs:
       - name: publish npm
         run: |
           cd js
-          npm publish
+          yarn publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/setup-python@v3
+
+      - name: build python package
+        with:
+          python-version: "3.10"
+      - run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+          python -m build
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - uses: actions/setup-node
+        with:
+          node-version: 18
+        run: |
+          cd js
+          npm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
-      - uses: actions/setup-node
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: publish npm

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter_rfb",
-  "version": "0.1.0",
+  "version": "0.4.1",
   "description": "Remote Frame Buffer for Jupyter",
   "author": "Almar Klein",
   "main": "lib/index.js",

--- a/jupyter_rfb/__init__.py
+++ b/jupyter_rfb/__init__.py
@@ -1,14 +1,8 @@
 # flake8: noqa
 from . import events
 from ._version import __version__, version_info
+from .widget import RemoteFrameBuffer
 from ._utils import remove_rfb_models_from_nb
-
-from ._colab import IN_COLAB
-
-if IN_COLAB:
-    from ._colab import RemoteFrameBuffer
-else:
-    from .widget import RemoteFrameBuffer
 
 
 def _jupyter_labextension_paths():

--- a/jupyter_rfb/__init__.py
+++ b/jupyter_rfb/__init__.py
@@ -1,8 +1,14 @@
 # flake8: noqa
 from . import events
 from ._version import __version__, version_info
-from .widget import RemoteFrameBuffer
 from ._utils import remove_rfb_models_from_nb
+
+from ._colab import IN_COLAB
+
+if IN_COLAB:
+    from ._colab import RemoteFrameBuffer
+else:
+    from .widget import RemoteFrameBuffer
 
 
 def _jupyter_labextension_paths():

--- a/jupyter_rfb/_colab.py
+++ b/jupyter_rfb/_colab.py
@@ -1,0 +1,34 @@
+from .widget import RemoteFrameBuffer as RFB
+
+try:
+    from google.colab import output
+    from google.colab.output._widgets import _installed_url
+except ModuleNotFoundError:
+    IN_COLAB = False
+else:
+    IN_COLAB = True
+
+    output.enable_custom_widget_manager()
+    COLAB_URL = _installed_url
+
+
+def get_colab_metadata():
+    """
+    Returns metadata required for colab
+    """
+    if not IN_COLAB:
+        return None
+
+    meta = dict()
+    meta["application/vnd.jupyter.widget-view+json"] = {
+        "colab": {"custom_widget_manager": {"url": COLAB_URL}}
+    }
+
+    return meta
+
+
+class RemoteFrameBuffer(RFB):
+    def _repr_mimebundle_(self, **kwargs):
+        data = super(RemoteFrameBuffer, self)._repr_mimebundle_(**kwargs)
+
+        return data, get_colab_metadata()

--- a/jupyter_rfb/_colab.py
+++ b/jupyter_rfb/_colab.py
@@ -2,7 +2,7 @@ try:
     # determine if running in colab
     from google.colab import output
     from google.colab.output._widgets import _installed_url
-except ModuleNotFoundError:
+except Exception:
     IN_COLAB = False
     COLAB_URL = None
 else:
@@ -15,9 +15,9 @@ else:
 
 def get_colab_metadata():
     """
-    Returns metadata required for colab if running in colab notebook.
-    Returns ``None` if not running in a colab notebook.
+    Gets metadata required for colab notebooks. Returns ``None` if not running in a colab notebook.
     """
+
     if not IN_COLAB:
         return None
 

--- a/jupyter_rfb/_colab.py
+++ b/jupyter_rfb/_colab.py
@@ -1,7 +1,6 @@
 try:
     # determine if running in colab
     from google.colab import output
-    from google.colab.output._widgets import _installed_url
 except Exception:
     IN_COLAB = False
     COLAB_URL = None
@@ -9,8 +8,6 @@ else:
     IN_COLAB = True
     # useful to enable widget manager here so the user doesn't have to manually
     output.enable_custom_widget_manager()
-    # the metadata that colab needs
-    COLAB_URL = _installed_url
 
 
 def get_colab_metadata():
@@ -22,7 +19,7 @@ def get_colab_metadata():
 
     if not IN_COLAB:
         return None
-
+      from google.colab.output._widgets import _installed_url as COLAB_URL
     meta = dict()
     meta["application/vnd.jupyter.widget-view+json"] = {
         "colab": {"custom_widget_manager": {"url": COLAB_URL}}

--- a/jupyter_rfb/_colab.py
+++ b/jupyter_rfb/_colab.py
@@ -1,20 +1,22 @@
-from .widget import RemoteFrameBuffer as RFB
-
 try:
+    # determine if running in colab
     from google.colab import output
     from google.colab.output._widgets import _installed_url
 except ModuleNotFoundError:
     IN_COLAB = False
+    COLAB_URL = None
 else:
     IN_COLAB = True
-
+    # useful to enable widget manager here so the user doesn't have to manually
     output.enable_custom_widget_manager()
+    # the metadata that colab needs
     COLAB_URL = _installed_url
 
 
 def get_colab_metadata():
     """
-    Returns metadata required for colab
+    Returns metadata required for colab if running in colab notebook.
+    Returns ``None` if not running in a colab notebook.
     """
     if not IN_COLAB:
         return None
@@ -25,10 +27,3 @@ def get_colab_metadata():
     }
 
     return meta
-
-
-class RemoteFrameBuffer(RFB):
-    def _repr_mimebundle_(self, **kwargs):
-        data = super(RemoteFrameBuffer, self)._repr_mimebundle_(**kwargs)
-
-        return data, get_colab_metadata()

--- a/jupyter_rfb/_colab.py
+++ b/jupyter_rfb/_colab.py
@@ -15,7 +15,9 @@ else:
 
 def get_colab_metadata():
     """
-    Gets metadata required for colab notebooks. Returns ``None` if not running in a colab notebook.
+    Get the metadata required for running in a colab notebook.
+
+    Returns ``None` if not running in a colab notebook.
     """
 
     if not IN_COLAB:

--- a/jupyter_rfb/_colab.py
+++ b/jupyter_rfb/_colab.py
@@ -20,6 +20,7 @@ def get_colab_metadata():
     if not IN_COLAB:
         return None
     from google.colab.output._widgets import _installed_url as COLAB_URL
+
     meta = dict()
     meta["application/vnd.jupyter.widget-view+json"] = {
         "colab": {"custom_widget_manager": {"url": COLAB_URL}}

--- a/jupyter_rfb/_colab.py
+++ b/jupyter_rfb/_colab.py
@@ -19,7 +19,7 @@ def get_colab_metadata():
 
     if not IN_COLAB:
         return None
-      from google.colab.output._widgets import _installed_url as COLAB_URL
+    from google.colab.output._widgets import _installed_url as COLAB_URL
     meta = dict()
     meta["application/vnd.jupyter.widget-view+json"] = {
         "colab": {"custom_widget_manager": {"url": COLAB_URL}}

--- a/jupyter_rfb/widget.py
+++ b/jupyter_rfb/widget.py
@@ -22,6 +22,7 @@ from IPython.display import display
 from traitlets import Bool, Dict, Int, Unicode
 
 from ._utils import array2compressed, RFBOutputContext, Snapshot
+from ._colab import get_colab_metadata
 
 
 @ipywidgets.register
@@ -123,6 +124,11 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
         # Add initial snapshot.
         if self._view_name is not None:
             data["text/html"] = self.snapshot()._repr_html_()
+
+        # attach colab metadata if running in a colab notebook
+        colab_metadata = get_colab_metadata()
+        if colab_metadata is not None:  # ``None`` if not running in colab
+            data = (data, colab_metadata)
 
         return data
 


### PR DESCRIPTION
closes #74 

`RemoteFrameBuffer._repr_mimebundle_` returns `(data, colab_metadata)` when running in colab. Also adds github action to publish to pypi and npm. Publishing to npm is required for running in colab since that's where it fetches widget stuff from.
