### PR TITLE
allow setting the cursor

### DIFF
--- a/js/lib/widget.js
+++ b/js/lib/widget.js
@@ -35,7 +35,8 @@ export class RemoteFrameBufferModel extends DOMWidgetModel {
             css_width: '500px',
             css_height: '300px',
             resizable: true,
-            has_visible_views: false
+            has_visible_views: false,
+            cursor: 'default'
         };
     }
     initialize() {
@@ -203,6 +204,10 @@ export class RemoteFrameBufferView extends DOMWidgetView {
         this.img.src = this.model.last_frame.src;
         this.el.appendChild(this.img);
         this.model.collect_view_img_elements();
+
+        // Cursor
+        this.el.style.cursor = this.model.get('cursor');
+        this.model.on('change:cursor', function () { this.el.style.cursor = this.model.get('cursor'); }, this);
 
         // Set of throttler functions to send events at a friendly pace
         this._throttlers = {};

--- a/jupyter_rfb/widget.py
+++ b/jupyter_rfb/widget.py
@@ -47,6 +47,8 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
     * *max_buffered_frames*: the number of frames that is allowed to be "in-flight",
       i.e. sent, but not yet confirmed by the client. Default 2. Higher values
       may result in a higher FPS at the cost of introducing lag.
+    * *cursor*: the cursor style, ex: "crosshair", "grab". Valid cursors:
+      https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#keyword
 
     """
 
@@ -75,6 +77,7 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
     css_width = Unicode("500px").tag(sync=True)
     css_height = Unicode("300px").tag(sync=True)
     resizable = Bool(True).tag(sync=True)
+    cursor = Unicode("default").tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -10,6 +10,7 @@ import numpy as np
 from pytest import raises
 from jupyter_rfb import RemoteFrameBuffer
 from jupyter_rfb._utils import Snapshot
+from traitlets import TraitError
 
 
 class MyRFB(RemoteFrameBuffer):
@@ -211,7 +212,7 @@ def test_widget_traits():
     assert w.max_buffered_frames == 2
     w.max_buffered_frames = 99
     w.max_buffered_frames = 1
-    with raises(Exception):  # TraitError -> min 1
+    with raises(TraitError):  # TraitError -> min 1
         w.max_buffered_frames = 0
 
     assert w.css_width.endswith("px")


### PR DESCRIPTION
Exposes `style.cursor` of the DOM element so that it can be changed. Tested with wgpu RFB canvas too.

https://github.com/vispy/jupyter_rfb/assets/9403332/a27c500a-9b08-4d28-8731-7457e50680da
