### PR TITLE
Use tuples for buttons and modifiers (instead of list)

### DIFF
--- a/jupyter_rfb/_version.py
+++ b/jupyter_rfb/_version.py
@@ -9,7 +9,9 @@ __version__ = "%s.%s.%s%s" % (
     version_info[0],
     version_info[1],
     version_info[2],
-    ""
-    if version_info[3] == "final"
-    else _specifier_[version_info[3]] + str(version_info[4]),
+    (
+        ""
+        if version_info[3] == "final"
+        else _specifier_[version_info[3]] + str(version_info[4])
+    ),
 )

--- a/jupyter_rfb/events.py
+++ b/jupyter_rfb/events.py
@@ -26,8 +26,8 @@ Event types
     * *x*: horizontal position of the pointer within the widget.
     * *y*: vertical position of the pointer within the widget.
     * *button*: the button to which this event applies. See section below for details.
-    * *buttons*: a list of buttons being pressed down.
-    * *modifiers*: a list of modifier keys being pressed down. See section below for details.
+    * *buttons*: a tuple of buttons being pressed down.
+    * *modifiers*: a tuple of modifier keys being pressed down. See section below for details.
     * *ntouches*: the number of simultaneous pointers being down.
     * *touches*: a dict with int keys (pointer id's), and values that are dicts
       that contain "x", "y", and "pressure".
@@ -63,14 +63,14 @@ Event types
     * *dy*: the vertical scroll delta (positive means scroll down or zoom out).
     * *x*: the mouse horizontal position during the scroll.
     * *y*: the mouse vertical position during the scroll.
-    * *buttons*: a list of buttons being pressed down.
-    * *modifiers*: a list of modifier keys being pressed down.
+    * *buttons*: a tuple of buttons being pressed down.
+    * *modifiers*: a tuple of modifier keys being pressed down.
     * *time_stamp*: a timestamp in seconds.
 
 * **key_down**: emitted when a key is pressed down.
 
     * *key*: the key being pressed as a string. See section below for details.
-    * *modifiers*: a list of modifier keys being pressed down.
+    * *modifiers*: a tuple of modifier keys being pressed down.
     * *time_stamp*: a timestamp in seconds.
 
 * **key_up**: emitted when a key is released.

--- a/jupyter_rfb/widget.py
+++ b/jupyter_rfb/widget.py
@@ -159,7 +159,7 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
                 self.request_draw()
             elif content["event_type"] == "close":
                 self._repr_mimebundle_ = None
-            # Turn lists into tuples
+            # Turn lists into tuples (js/json does not have tuples)
             if "buttons" in content:
                 content["buttons"] = tuple(content["buttons"])
             if "modifiers" in content:

--- a/jupyter_rfb/widget.py
+++ b/jupyter_rfb/widget.py
@@ -159,6 +159,11 @@ class RemoteFrameBuffer(ipywidgets.DOMWidget):
                 self.request_draw()
             elif content["event_type"] == "close":
                 self._repr_mimebundle_ = None
+            # Turn lists into tuples
+            if "buttons" in content:
+                content["buttons"] = tuple(content["buttons"])
+            if "modifiers" in content:
+                content["modifiers"] = tuple(content["modifiers"])
             # Let the subclass handle the event
             with self._output_context:
                 self.handle_event(content)


### PR DESCRIPTION
This provides a cleaner experience for downstream code.