### PR TITLE
fix(ci): add RTD config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.11'
+  apt_packages:
+  - freeglut3-dev
+  - xvfb
+  - x11-utils
+  jobs:
+    post_system_dependencies:
+    - nohup Xvfb $DISPLAY -screen 0 1400x900x24 -dpi 96 +extension RANDR +render &
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+python:
+  install:
+  - method: pip
+    path: .
+  - requirements: docs/docs_requirements.txt


### PR DESCRIPTION
EDIT: that would be great to enable RTD builds on PRs, to check if my fix is working or not :-)

---

Hello,

RTD builds are broken because they need some config file.
I just copy/pasted [some RTD config file from a personal project](https://github.com/jeertmans/DiffeRT/blob/39d94543a2236e046fa9ee1f3ebfff56410eb51e/.readthedocs.yaml) that happens
to use jupyter_rfb and VisPy too in the documentation.

Closes #96