### PR TITLE
Fix pygfx example 1

### DIFF
--- a/examples/pygfx1.ipynb
+++ b/examples/pygfx1.ipynb
@@ -68,7 +68,7 @@
     "disp = gfx.Display()\n",
     "disp.before_render = animate\n",
     "disp.stats = True\n",
-    "disp.show(cube)",
+    "disp.show(cube)\n",
     "disp.canvas"
    ]
   },

--- a/examples/pygfx1.ipynb
+++ b/examples/pygfx1.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "**Note that this example depends on pygfx (`pip install -U pygfx`).**\n",
     "\n",
-    "An example showing a lit, textured, rotating cube. Tested against pygfx v0.1.15."
+    "An example showing a lit, textured, rotating cube. Tested against pygfx v0.7.0."
    ]
   },
   {
@@ -68,7 +68,8 @@
     "disp = gfx.Display()\n",
     "disp.before_render = animate\n",
     "disp.stats = True\n",
-    "disp.show(cube)"
+    "disp.show(cube)",
+    "disp.canvas"
    ]
   },
   {


### PR DESCRIPTION
Small fix for Issue https://github.com/vispy/jupyter_rfb/issues/113.

Added the `disp.canvas` instruction and changed last tested version to 0.7.0 of pygfx. 
The other examples use a slightly different structure but I thought it is best to keep the first example mostly as is.