### PR TITLE
Use explicit jupyter_rfb backend for pygfx

### DIFF
--- a/examples/pygfx2.ipynb
+++ b/examples/pygfx2.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import pygfx as gfx\n",
-    "from rendercanvas.auto import RenderCanvas"
+    "from rendercanvas.jupyter import RenderCanvas"
    ]
   },
   {

--- a/examples/pygfx3.ipynb
+++ b/examples/pygfx3.ipynb
@@ -20,7 +20,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from rendercanvas.auto import RenderCanvas\n",
+    "from rendercanvas.jupyter import RenderCanvas\n",
     "import pygfx as gfx"
    ]
   },


### PR DESCRIPTION
On hold, since maybe we'll rename the backend to `jupyter_rfb` for clarity. -> Nah, won't rename.